### PR TITLE
Bard: Apex Arrow Logic Change

### DIFF
--- a/Magitek/Logic/Bard/Aoe.cs
+++ b/Magitek/Logic/Bard/Aoe.cs
@@ -58,7 +58,7 @@ namespace Magitek.Logic.Bard
             if (!BardSettings.Instance.ApexArrow)
                 return false;
 
-            if (MagitekActionResourceManager.Bard.SoulVoice < BardSettings.Instance.ApexArrowMinimumSoulVoice)
+            if (MagitekActionResourceManager.Bard.SoulVoice <= BardSettings.Instance.ApexArrowMinimumSoulVoice)
                 return false;
 
             return await Spells.ApexArrow.Cast(Core.Me.CurrentTarget);


### PR DESCRIPTION
"Apex Arrow When We Have At Least YX Soul Voice", instead of > it should be >=, its more natural than keeping the threshold 1 below your desired value