### PR TITLE
BARNES & NOBLE SPECIAL

### DIFF
--- a/Magitek/Logic/Scholar/Buff.cs
+++ b/Magitek/Logic/Scholar/Buff.cs
@@ -80,8 +80,14 @@ namespace Magitek.Logic.Scholar
 
             if (Core.Me.HasAetherflow())
                 return false;
-
+            if (Spells.Aetherflow.Cooldown.TotalMilliseconds > 1500)
+                return false;
+            if (Casting.LastSpell != Spells.Biolysis || Casting.LastSpell != Spells.ArtOfWar || Casting.LastSpell != Spells.Adloquium || Casting.LastSpell != Spells.Succor)
+                if (await Spells.Ruin2.Cast(Core.Me.CurrentTarget))
+                    return true;
             return await Spells.Aetherflow.Cast(Core.Me);
+            
+            
         }
 
         public static async Task<bool> DeploymentTactics()
@@ -96,7 +102,9 @@ namespace Magitek.Logic.Scholar
 
             if (deploymentTacticsTarget == null)
                 return false;
-
+            if (Casting.LastSpell != Spells.Biolysis || Casting.LastSpell != Spells.ArtOfWar || Casting.LastSpell != Spells.Adloquium || Casting.LastSpell != Spells.Succor)
+                if (await Spells.Ruin2.Cast(Core.Me.CurrentTarget))
+                    return true;
             return await Spells.DeploymentTactics.Cast(deploymentTacticsTarget);
         }
 
@@ -111,6 +119,13 @@ namespace Magitek.Logic.Scholar
             if (Core.Me.CurrentManaPercent > ScholarSettings.Instance.LucidDreamingManaPercent)
                 return false;
 
+            if (Spells.LucidDreaming.Cooldown.TotalMilliseconds > 1500)
+                return false; 
+
+            //force ruin 2 cast to open GCD 
+            if (Casting.LastSpell != Spells.Biolysis || Casting.LastSpell != Spells.ArtOfWar || Casting.LastSpell != Spells.Adloquium || Casting.LastSpell != Spells.Succor)
+                if (await Spells.Ruin2.Cast(Core.Me.CurrentTarget))
+                    return true;
             return await Spells.LucidDreaming.Cast(Core.Me);
         }
 
@@ -122,8 +137,13 @@ namespace Magitek.Logic.Scholar
             if (!ActionManager.HasSpell(Spells.ChainStrategem.Id))
                 return false;
 
+            if (Spells.ChainStrategem.Cooldown.TotalMilliseconds > 1500)
+                return false;
+
             switch (ScholarSettings.Instance.ChainStrategemsStrategy)
+
             {
+                
                 case ChainStrategemStrategemStrategy.Never:
                     return false;
 
@@ -135,7 +155,9 @@ namespace Magitek.Logic.Scholar
 
                     if (chainStrategemsTarget == null)
                         return false;
-
+                    if (Casting.LastSpell != Spells.Biolysis || Casting.LastSpell != Spells.ArtOfWar || Casting.LastSpell != Spells.Adloquium || Casting.LastSpell != Spells.Succor)
+                        if (await Spells.Ruin2.Cast(Core.Me.CurrentTarget))
+                            return true;
                     return await Spells.ChainStrategem.Cast(chainStrategemsTarget);
 
                 case ChainStrategemStrategemStrategy.OnlyBosses:
@@ -146,7 +168,9 @@ namespace Magitek.Logic.Scholar
 
                     if (chainStrategemsBossTarget == null)
                         return false;
-
+                    if (Casting.LastSpell != Spells.Biolysis || Casting.LastSpell != Spells.ArtOfWar || Casting.LastSpell != Spells.Adloquium || Casting.LastSpell != Spells.Succor)
+                        if (await Spells.Ruin2.Cast(Core.Me.CurrentTarget))
+                            return true;
                     return await Spells.ChainStrategem.Cast(chainStrategemsBossTarget);
 
                 default:
@@ -183,7 +207,9 @@ namespace Magitek.Logic.Scholar
 
             if (aetherpactTarget == null)
                 return false;
-
+            if (Casting.LastSpell != Spells.Biolysis || Casting.LastSpell != Spells.ArtOfWar || Casting.LastSpell != Spells.Adloquium || Casting.LastSpell != Spells.Succor)
+                if (await Spells.Ruin2.Cast(Core.Me.CurrentTarget))
+                    return true;
             return await Spells.Aetherpact.Cast(aetherpactTarget);
 
             bool CanAetherpact(GameObject unit)

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -331,6 +331,9 @@ namespace Magitek.Logic.Scholar
             if (!Core.Me.HasAetherflow())
                 return false;
 
+            if (Group.CastableAlliesWithin15.Count(r => r.CurrentHealthPercent <= ScholarSettings.Instance.IndomitabilityHpPercent) > ScholarSettings.Instance.IndomitabilityNeedHealing)
+                return false;
+
             if (Globals.InParty)
             {
                 var lustrateTarget = Group.CastableAlliesWithin30.FirstOrDefault(CanLustrate);

--- a/Magitek/Logic/Scholar/SingleTarget.cs
+++ b/Magitek/Logic/Scholar/SingleTarget.cs
@@ -94,9 +94,15 @@ namespace Magitek.Logic.Scholar
             if (!Core.Me.HasAetherflow())
             return false;
 
-            if (Spells.Aetherflow.Cooldown.TotalMilliseconds >= 12000)
-                return false; 
-
+            if (ActionResourceManager.Scholar.Aetherflow == 3 && Spells.Aetherflow.Cooldown.TotalMilliseconds > 8000)
+                return false;
+            if (ActionResourceManager.Scholar.Aetherflow == 2 && Spells.Aetherflow.Cooldown.TotalMilliseconds > 6000)
+                return false;
+            if (ActionResourceManager.Scholar.Aetherflow == 1 && Spells.Aetherflow.Cooldown.TotalMilliseconds > 4000)
+                return false;
+            if (Casting.LastSpell != Spells.Biolysis || Casting.LastSpell != Spells.ArtOfWar || Casting.LastSpell != Spells.Adloquium || Casting.LastSpell != Spells.Succor)
+                if (await Spells.Ruin2.Cast(Core.Me.CurrentTarget))
+                    return true;
             return await Spells.EnergyDrain2.Cast(Core.Me.CurrentTarget);
         }
     }

--- a/Magitek/Logic/Summoner/SingleTarget.cs
+++ b/Magitek/Logic/Summoner/SingleTarget.cs
@@ -49,7 +49,7 @@ namespace Magitek.Logic.Summoner
         {
             if (!SummonerSettings.Instance.Bio) return false;
 
-            if (Spells.TriDisaster.Cooldown.TotalMilliseconds <= SummonerSettings.Instance.DotRefreshSeconds * 1000)
+            if (Spells.TriDisaster.Cooldown.TotalMilliseconds <= SummonerSettings.Instance.DotRefreshSeconds * 1000 && Core.Me.ClassLevel > 53)
                 return false;
 
             return !Core.Me.CurrentTarget.HasAnyAura(Utilities.Routines.Summoner.BioAuras, true, SummonerSettings.Instance.DotRefreshSeconds * 1000)
@@ -63,7 +63,7 @@ namespace Magitek.Logic.Summoner
             if (MovementManager.IsMoving) return false;
             var refresh = SummonerSettings.Instance.DotRefreshSeconds * 1000;
 
-            if (Spells.TriDisaster.Cooldown.TotalMilliseconds <= refresh)
+            if (Spells.TriDisaster.Cooldown.TotalMilliseconds <= refresh && Core.Me.ClassLevel > 53)
                 return false;
 
             switch (Core.Me.ClassLevel)


### PR DESCRIPTION
- Huge SCH oGCD-use overhaul:
> Will now weave Ruin 2 before any oGCD if the GCD isn't open
> Will start dumping Aetherflow with Energy Drain if AF is about to come back
> Will no longer spaz and use 2 lustrates + indom when whole party gets very low, prioritizing AoE healing first

- Low level SMN logic bugfix 
(Thanks Rivvs)


