### PR TITLE
Remove avoid check which is always true if a mob is casting an AOE

### DIFF
--- a/Magitek/Utilities/Movement.cs
+++ b/Magitek/Utilities/Movement.cs
@@ -23,8 +23,8 @@ namespace Magitek.Utilities
             if (!MovementManager.IsMoving && !unit.InView())
                 Core.Me.Face(Core.Me.CurrentTarget);
 
-            if (AvoidanceManager.Avoids.Any(r => r.IsPointInAvoid(unit.Location)))
-                return;
+    //        if (AvoidanceManager.Avoids.Any(r => r.IsPointInAvoid(unit.Location)))
+    //            return;
 
             if (unit.Distance(Core.Me) > distance)
             {


### PR DESCRIPTION
So it stops running out of an avoid until the spell stops casting. The check is unnecessary since Sidestep sets the Disallow movement flag so if (RoutineManager.IsAnyDisallowed(CapabilityFlags.Movement)) hits first which returns but when the character is outside of the avoid zone the next check it hits is this one. Now it's still running away but if (AvoidanceManager.Avoids.Any(r => r.IsPointInAvoid(unit.Location))) is always true if the mob is casting the aoe even if you're outside it...even if you're behind or next to the mob outside the casting cone since the target itself is still inside the avoid. The Navigator will respect avoids if the distance is greater and if you're within casting distance it will stop and continue attacking. 