### PR TITLE
Some updates on MCH

### DIFF
--- a/Magitek/Logic/Machinist/Cooldowns.cs
+++ b/Magitek/Logic/Machinist/Cooldowns.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
-using Buddy.Coroutines;
 using ff14bot;
 using ff14bot.Managers;
 using Magitek.Extensions;
@@ -35,13 +34,21 @@ namespace Magitek.Logic.Machinist
 
         public static async Task<bool> Hypercharge()
         {
+
             if (!MachinistSettings.Instance.UseHypercharge)
+                return false;
+
+            // Not necessary to continue checking if Heat is not at 50
+            if (ActionResourceManager.Machinist.Heat < 50)
                 return false;
 
             if (Spells.Drill.Cooldown.TotalMilliseconds < 8000 || MachinistGlobals.HotAirAnchor.Cooldown.TotalMilliseconds < 8000)
                 return false;
 
             if (Spells.Ricochet.Charges >= 2.0f || Spells.GaussRound.Charges >= 2.0f)
+                return false;
+
+            if (Spells.Ricochet.Charges < 0.5f && Spells.GaussRound.Charges < 0.5f)
                 return false;
 
             //Force Delay CD
@@ -77,42 +84,16 @@ namespace Magitek.Logic.Machinist
 
             if (ActionResourceManager.Machinist.Heat < 50 && ActionResourceManager.Machinist.OverheatRemaining == TimeSpan.Zero)
                 return false;
+ 
+            if (Spells.Ricochet.Charges < 0.5f && Spells.GaussRound.Charges < 0.5f)
+                return false;
 
             //Force Delay CD
             if (Spells.SplitShot.Cooldown.TotalMilliseconds > 1000 + BaseSettings.Instance.UserLatencyOffset)
-            return false;
+                return false;
 
             return await Spells.Wildfire.Cast(Core.Me.CurrentTarget);
         }
-        /* OLD LOGIC FOR REFERENCE
-        public static async Task<bool> Hypercharge()
-        {
-            if (!MachinistSettings.Instance.UseHypercharge)
-                return false;
-
-            if (!MachinistSettings.Instance.UseWildfire || !ActionManager.CurrentActions.Values.Contains(Spells.Wildfire))
-                return await Spells.Hypercharge.Cast(Core.Me);
-
-            if (Spells.Wildfire.Cooldown.Seconds > 10 || Spells.Wildfire.Cooldown.Seconds < 1)
-                return await Spells.Hypercharge.Cast(Core.Me);
-
-            return false;
-        }
-
-        public static async Task<bool> Wildfire()
-        {
-            if (!MachinistSettings.Instance.UseWildfire)
-                return false;
-
-            if (Core.Me.HasAura(Auras.WildfireBuff, true))
-                return false;
-
-            if (!MachinistSettings.Instance.UseHypercharge)
-                if (ActionResourceManager.Machinist.Heat <= 45 && Casting.SpellCastHistory.Take(5).All(s => s.Spell != Spells.Hypercharge))
-                    return false;
-
-            return await Spells.Wildfire.Cast(Core.Me.CurrentTarget);
-        }*/
 
         public static async Task<bool> Reassemble()
         {

--- a/Magitek/Logic/Machinist/MultiTarget.cs
+++ b/Magitek/Logic/Machinist/MultiTarget.cs
@@ -103,14 +103,11 @@ namespace Magitek.Logic.Machinist
             {
                 if (Spells.Wildfire.Cooldown.Seconds < 2)
                     return false;
+
+                // Do not run Rico if an hypercharge is almost ready and not enough charges available for Rico and Gauss
+                if (ActionResourceManager.Machinist.Heat > 45 && Spells.Hypercharge.Cooldown == TimeSpan.Zero && Spells.Ricochet.Charges < 1.5f && Spells.GaussRound.Charges < 1.5f)
+                    return false;
             }
-
-            /*if (Core.Me.CurrentTarget.EnemiesNearby(5).Count() < MachinistSettings.Instance.RicochetEnemyCount)
-                return false;*/
-
-            /*add some mor precise logic for pooling/dumping
-            if (Spells.Ricochet.Charges < 1.8f)
-                return false;*/
 
             return await Spells.Ricochet.Cast(Core.Me.CurrentTarget);
         }

--- a/Magitek/Logic/Machinist/Pet.cs
+++ b/Magitek/Logic/Machinist/Pet.cs
@@ -22,9 +22,6 @@ namespace Magitek.Logic.Machinist
             if (ActionResourceManager.Machinist.OverheatRemaining > TimeSpan.Zero)
                 return false;
 
-            //if (Core.Me.HasTarget && Core.Me.Distance2D(Core.Me.CurrentTarget) > 30)
-            //    return false;
-
             if (!MachinistGlobals.IsInWeaveingWindow)
                 return false;
 
@@ -39,9 +36,11 @@ namespace Magitek.Logic.Machinist
                 if (Casting.LastSpell == Spells.Wildfire)
                     return false;
 
-                if (Spells.Wildfire.Cooldown.Seconds < 11)
+                // Do not understand the reason behind
+                /*
+                   if (Spells.Wildfire.Cooldown.Seconds < 11)
                     return false;
-
+                */
                 if (Spells.Wildfire.Cooldown.Seconds > 110)
                     return false;
             }

--- a/Magitek/Rotations/Machinist.cs
+++ b/Magitek/Rotations/Machinist.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using ff14bot;
 using ff14bot.Managers;
 using Magitek.Extensions;
@@ -11,6 +7,7 @@ using Magitek.Logic.Machinist;
 using Magitek.Logic.Roles;
 using Magitek.Models.Machinist;
 using Magitek.Utilities;
+using MachinistGlobals = Magitek.Utilities.Routines.Machinist;
 
 namespace Magitek.Rotations
 {
@@ -85,11 +82,12 @@ namespace Magitek.Rotations
 
             if (MachinistSettings.Instance.UseFlamethrower && Core.Me.HasAura(Auras.Flamethrower))
             {
-                if (!MachinistSettings.Instance.UseFlamethrower)
-                    return true;
-
+                // First check movement otherwise Flamethrower can be executed whereas you are moving
                 if (MovementManager.IsMoving)
                     return false;
+
+                if (!MachinistSettings.Instance.UseFlamethrower)
+                    return true;
 
                 if (Core.Me.EnemiesInCone(8) >= MachinistSettings.Instance.FlamethrowerEnemyCount)
                     return true;
@@ -105,20 +103,20 @@ namespace Magitek.Rotations
 
             if (Weaving.GetCurrentWeavingCounter() < 2)
             {
+                //Pets
+                if (await Pet.RookQueen()) return true;
+                if (await Pet.RookQueenOverdrive()) return true;
+
                 //Cooldowns
                 if (await Cooldowns.Wildfire()) return true;
                 if (await Cooldowns.Hypercharge()) return true;
                 if (await Cooldowns.Reassemble()) return true;
                 if (await Cooldowns.BarrelStabilizer()) return true;
-                if (await Pet.RookQueen()) return true;
-                if (await Pet.RookQueenOverdrive()) return true;
+
                 //oGCDs
                 if (await SingleTarget.GaussRound()) return true;
                 if (await MultiTarget.Ricochet()) return true;
             }
-
-
-
 
             //GCDs - Top Hypercharge Priority
             if (await MultiTarget.AutoCrossbow()) return true;
@@ -134,6 +132,7 @@ namespace Magitek.Rotations
             if (await MultiTarget.SpreadShot()) return true;
             if (await SingleTarget.HeatedCleanShot()) return true;
             if (await SingleTarget.HeatedSlugShot()) return true;
+
             return await SingleTarget.HeatedSplitShot();
         }
         public static async Task<bool> PvP()

--- a/Magitek/Utilities/Routines/Machinist.cs
+++ b/Magitek/Utilities/Routines/Machinist.cs
@@ -1,19 +1,40 @@
 ﻿using System;
-using System.Collections.Generic;
 using ff14bot;
 using ff14bot.Managers;
 using ff14bot.Objects;
 using Magitek.Models.Machinist;
+
 
 namespace Magitek.Utilities.Routines
 {
     internal static class Machinist
     {
         public static int AnimationLock = 700;
-        public static bool IsInWeaveingWindow => ActionResourceManager.Machinist.OverheatRemaining != TimeSpan.Zero 
-                                                ? Weaving.GetCurrentWeavingCounter() < 1 && HeatedSplitShot.Cooldown != TimeSpan.Zero 
+        public static bool IsInWeaveingWindow => ActionResourceManager.Machinist.OverheatRemaining != TimeSpan.Zero
+                                                ? Weaving.GetCurrentWeavingCounter() < 1 && HeatedSplitShot.Cooldown != TimeSpan.Zero
                                                 : Weaving.GetCurrentWeavingCounter() < 2 && HeatedSplitShot.Cooldown != TimeSpan.Zero
-                                                                                         && HeatedSplitShot.Cooldown.TotalMilliseconds > AnimationLock + 50 + MachinistSettings.Instance.UserLatencyOffset;
+                                                                            && HeatedSplitShot.Cooldown.TotalMilliseconds > AnimationLock + 50 + MachinistSettings.Instance.UserLatencyOffset;
+
+
+        /*
+        // Export IsInWeaveingWindow in a method to help for debug if necessary
+        public static bool IsInWeaveingWindow => IsInWeaveingWindowMethod();
+        public static bool IsInWeaveingWindowMethod()
+        {
+            var heatedSplitShotCooldown = HeatedSplitShot.Cooldown;
+            var heatedSplitShotCooldownTotalMilliseconds = HeatedSplitShot.Cooldown.TotalMilliseconds;
+            var currentWeavingCounter = Weaving.GetCurrentWeavingCounter();
+
+            
+            //Logger.WriteInfo($@"heatedSplitShotCooldownTotalMilliseconds: {heatedSplitShotCooldownTotalMilliseconds}");
+            //Logger.WriteInfo($@"currentWeavingCounter: {currentWeavingCounter}");
+
+            return ActionResourceManager.Machinist.OverheatRemaining != TimeSpan.Zero
+                                                ? currentWeavingCounter < 1 && heatedSplitShotCooldown != TimeSpan.Zero
+                                                : currentWeavingCounter < 2 && heatedSplitShotCooldown != TimeSpan.Zero
+                                                                            && heatedSplitShotCooldownTotalMilliseconds > AnimationLock + 50 + MachinistSettings.Instance.UserLatencyOffset;
+        }
+        */
 
         //skill upgrades
         public static SpellData HeatedSplitShot => Core.Me.ClassLevel < 54 //|| !ActionManager.HasSpell(Spells.HeatedSplitShot.Id)

--- a/Magitek/Utilities/Weaving.cs
+++ b/Magitek/Utilities/Weaving.cs
@@ -365,15 +365,12 @@ namespace Magitek.Utilities
             if (Casting.SpellCastHistory.Count < 2)
                 return 0;
 
-            var lastSpellCast = Casting.SpellCastHistory.ElementAt(0).Spell;
-            var secondLastSpellCast = Casting.SpellCastHistory.ElementAt(1).Spell;
-
-            if (NonWeaponskills[Core.Me.CurrentJob].Contains(lastSpellCast))
+            if (NonWeaponskills[Core.Me.CurrentJob].Contains(Casting.SpellCastHistory.ElementAt(0).Spell))
                 weavingCounter += 1;
             else
                 return 0;
 
-            if (NonWeaponskills[Core.Me.CurrentJob].Contains(secondLastSpellCast))
+            if (NonWeaponskills[Core.Me.CurrentJob].Contains(Casting.SpellCastHistory.ElementAt(1).Spell))
                 weavingCounter += 1;
 
             return weavingCounter;


### PR DESCRIPTION
Some updates on MCH:
- Code cleaning
- Comments added for debug
- FlammeThrower : check movement first
- In Combat routine, move pets before Cooldowns
- Remove condition on Latency for HeatedSplitShot as concerned everybody
- Delay Anchor if Battery is almost full to avoid wasting it
- Do not consume Last Gauss or Rico charge if Hypercharge ready and Heat almost at 50 in order to keep them and not delay Hypercharge
- Remove condition of RookQueen which return false if Wildfire cooldown < 11
- Adding a check on Heat for Hypercharge to prevent doing many check after which are unnecessary if Heat is lower than 50