### PR TITLE
Minor AST logic changes Major RDM changes

### DIFF
--- a/Magitek/Logic/Astrologian/Cards.cs
+++ b/Magitek/Logic/Astrologian/Cards.cs
@@ -62,7 +62,8 @@ namespace Magitek.Logic.Astrologian
             if (Combat.CombatTotalTimeLeft <= AstrologianSettings.Instance.DontPlayWhenCombatTimeIsLessThan)
                 return false;
 
-            if (DivinationSeals.All(c => c != 0) && AstrologianSettings.Instance.Divination)
+            // Added check to see if more than 2 people are around
+            if (DivinationSeals.All(c => c != 0) && AstrologianSettings.Instance.Divination && Group.CastableAlliesWithin15.Count() >= 2)
                 await Spells.Divination.Cast(Core.Me);
 
             if (!AstrologianSettings.Instance.Play)
@@ -92,7 +93,8 @@ namespace Magitek.Logic.Astrologian
             var ally = Group.CastableAlliesWithin30.Where(a => !a.HasAnyCardAura() && a.IsAlive && (a.IsTank() || a.IsMeleeDps())).OrderBy(GetWeight);
             
             if(minor)
-                return await Spells.MinorArcana.Cast(ally.FirstOrDefault());
+                // Action changed to LordofCrowns from MinorArcana
+                return await Spells.LordofCrowns.Cast(ally.FirstOrDefault());
 
             return await Spells.Play.Cast(ally.FirstOrDefault());
         }
@@ -102,7 +104,8 @@ namespace Magitek.Logic.Astrologian
             var ally = Group.CastableAlliesWithin30.Where(a => !a.HasAnyCardAura() && a.IsAlive && (a.IsHealer() || a.IsRangedDpsCard())).OrderBy(GetWeight);
 
             if (minor)
-                return await Spells.MinorArcana.Cast(ally.FirstOrDefault());
+                // Action changed to Lady of Crowns from MinorArcana
+                return await Spells.LadyofCrowns.Cast(ally.FirstOrDefault());
 
             return await Spells.Play.Cast(ally.FirstOrDefault());
         }

--- a/Magitek/Logic/RedMage/Buff.cs
+++ b/Magitek/Logic/RedMage/Buff.cs
@@ -14,20 +14,28 @@ namespace Magitek.Logic.RedMage
         {
             if (!RedMageSettings.Instance.Acceleration)
                 return false;
+
+            if (!Core.Me.InCombat)
+                return false;
 			
 			if (Core.Me.ClassLevel < 50)
                 return false;
 
             if (Core.Me.HasAura(Auras.VerfireReady) || Core.Me.HasAura(Auras.VerstoneReady))
                 return false;
+
+            if (WhiteMana >= 60 && BlackMana >=60 && Core.Me.HasAura(Auras.VerfireReady) && Core.Me.HasAura(Auras.VerstoneReady))
+                return false;
 			
-			else
-				return await Spells.Acceleration.Cast(Core.Me);
+			return await Spells.Acceleration.Cast(Core.Me);
         }
 
         public static async Task<bool> Embolden()
         {
             if (!RedMageSettings.Instance.Embolden)
+                return false;
+            
+            if (!Core.Me.InCombat)
                 return false;
 
             if (Core.Me.ClassLevel < 58)
@@ -36,8 +44,7 @@ namespace Magitek.Logic.RedMage
             if (ActionManager.LastSpell != Spells.Zwerchhau)
                 return false;
 			
-			else
-				return await Spells.Embolden.Cast(Core.Me);
+            return await Spells.Embolden.Cast(Core.Me);
         }
         
         public static async Task<bool> LucidDreaming()
@@ -51,8 +58,7 @@ namespace Magitek.Logic.RedMage
             if (Core.Me.CurrentManaPercent > RedMageSettings.Instance.LucidDreamingManaPercent)
                 return false;
 			
-			else
-				return await Spells.LucidDreaming.Cast(Core.Me);
+			return await Spells.LucidDreaming.Cast(Core.Me);
         }
 
         public static async Task<bool> Manafication()
@@ -60,12 +66,13 @@ namespace Magitek.Logic.RedMage
             if (!RedMageSettings.Instance.Manafication)
                 return false;
 
-            if (ActionManager.LastSpell != Spells.Jolt && ActionManager.LastSpell != Spells.Jolt2)
-                return false;
+            // Why tho?
+            //if (ActionManager.LastSpell != Spells.Jolt && ActionManager.LastSpell != Spells.Jolt2)
+            //    return false;
 
             // Can this be simplified? Yes
             // I like the readability though
-            if (WhiteMana < RedMageSettings.Instance.ManaficationMinimumBlackAndWhiteMana)
+            /*if (WhiteMana < RedMageSettings.Instance.ManaficationMinimumBlackAndWhiteMana)
                 return false;
             
             if (BlackMana < RedMageSettings.Instance.ManaficationMinimumBlackAndWhiteMana)
@@ -75,10 +82,14 @@ namespace Magitek.Logic.RedMage
                 return false;
 
             if (BlackMana > RedMageSettings.Instance.ManaficationMaximumBlackAndWhiteMana)
+                return false;*/
+
+            // Should really only be between 40 and 50 for optimal use
+
+			if (WhiteMana < 40 || WhiteMana > 50 || BlackMana < 40 || BlackMana > 50)
                 return false;
-			
-			else
-				return await Spells.Manafication.Cast(Core.Me);
+
+			return await Spells.Manafication.Cast(Core.Me);
         }
     }
 }

--- a/Magitek/Rotations/Astrologian.cs
+++ b/Magitek/Rotations/Astrologian.cs
@@ -36,7 +36,12 @@ namespace Magitek.Rotations
             if (ActionResourceManager.Astrologian.Arcana == ActionResourceManager.Astrologian.AstrologianCard.None)
                 await Spells.Draw.Cast(Core.Me);
 
-            return await Buff.Sect();
+            // Check to see if both sects can be used
+            if (Core.Me.ClassLevel >= Spells.NocturnalSect.LevelAcquired)
+                return await Buff.Sect();
+
+            // If not, use dinural
+            return await DiurnalSect();
         }
 
         public static async Task<bool> Pull()

--- a/Magitek/Rotations/Summoner.cs
+++ b/Magitek/Rotations/Summoner.cs
@@ -8,6 +8,7 @@ using ff14bot.Managers;
 using Magitek.Extensions;
 using Magitek.Logic;
 using Magitek.Logic.Summoner;
+using Magitek.Models.Summoner;
 using Magitek.Utilities;
 
 namespace Magitek.Rotations


### PR DESCRIPTION
AST:
- Fixed minor arcana to use correct ability for lord/lady
- Will now wait for 2+ allies to be in range before divination
- Check for usage of Noct sect added, if not available will default to Dinaural

RDM:
- Moved buffs from combat to combat buff
- Added logic to combatbuff for fixing procs/mana if above 80 mana and accel is on CD
- Added logic to combat to fish for procs below 80 if both verfire ready and verstone ready are up
- Fixed logic for black/white mana on scatter
- Check if in combat before using Accel and Embolden
- Statically set Manafication mana to between 40-50, this is optimal
- Replaced await line for moulinet with spellqueue logic

SMN:
For some reason, using Magitek.Models.Summoner was not there, no wonder why settings were not being saved or applied.

Added this back in.