### PR TITLE
RDM: Small improvements

### DIFF
--- a/Magitek/Models/RedMage/RedMageSettings.cs
+++ b/Magitek/Models/RedMage/RedMageSettings.cs
@@ -33,7 +33,7 @@ namespace Magitek.Models.RedMage
         [Setting]
         [DefaultValue(true)]
         public bool Acceleration { get; set; }
-        
+
         [Setting]
         [DefaultValue(true)]
         public bool Displacement { get; set; }
@@ -45,6 +45,10 @@ namespace Magitek.Models.RedMage
         [Setting]
         [DefaultValue(true)]
         public bool CorpsACorps { get; set; }
+
+        [Setting]
+        [DefaultValue(false)]
+        public bool CorpsACorpsInMeleeRangeOnly { get; set; }
 
         [Setting]
         [DefaultValue(true)]

--- a/Magitek/Rotations/RedMage.cs
+++ b/Magitek/Rotations/RedMage.cs
@@ -7,7 +7,7 @@ using Magitek.Logic;
 using Magitek.Logic.RedMage;
 using Magitek.Models.RedMage;
 using Magitek.Utilities;
-using static ff14bot.Managers.ActionResourceManager.RedMage;
+using RedMageRoutines = Magitek.Utilities.Routines.RedMage;
 
 namespace Magitek.Rotations
 {
@@ -84,7 +84,7 @@ namespace Magitek.Rotations
             if (await Buff.Manafication()) return true;
             if (await Buff.LucidDreaming()) return true;
 
-            if (Utilities.Routines.RedMage.GcdMsRemaining >= 700 && Casting.LastSpell != Spells.CorpsACorps)
+            if (RedMageRoutines.CanWeave)
             {
                 if (await SingleTarget.Fleche()) return true;
                 if (await Aoe.ContreSixte()) return true;
@@ -117,6 +117,7 @@ namespace Magitek.Rotations
             if (await Buff.Acceleration()) return true;
             return await SingleTarget.Jolt();
         }
+
         public static async Task<bool> PvP()
         {
             return false;

--- a/Magitek/Utilities/Routines/RedMage.cs
+++ b/Magitek/Utilities/Routines/RedMage.cs
@@ -4,6 +4,6 @@ namespace Magitek.Utilities.Routines
 {
     internal static class RedMage
     {
-        public static double GcdMsRemaining => Spells.Riposte.Cooldown.TotalMilliseconds;
+        public static bool CanWeave => Spells.Riposte.Cooldown.TotalMilliseconds >= 700;
     }
 }

--- a/Magitek/Views/UserControls/RedMage/SingleTarget.xaml
+++ b/Magitek/Views/UserControls/RedMage/SingleTarget.xaml
@@ -15,7 +15,10 @@
                 <CheckBox Content="Use Melee" IsChecked="{Binding RedMageSettings.UseMelee, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                 <CheckBox Margin="0,3,0,0" Content="Displacement" IsChecked="{Binding RedMageSettings.Displacement, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                 <CheckBox Margin="0,3,0,0" Content="Engagement" IsChecked="{Binding RedMageSettings.Engagement, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                <CheckBox Margin="0,3,0,0" Content="Corps-a-corps" IsChecked="{Binding RedMageSettings.CorpsACorps, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                <StackPanel Margin="0,3,0,0" Orientation="Horizontal">
+                    <CheckBox Margin="0,0,0,0" Content="Corps-a-corps   " IsChecked="{Binding RedMageSettings.CorpsACorps, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <CheckBox Margin="0,0,0,0" Content="Only in Melee Range" IsChecked="{Binding RedMageSettings.CorpsACorpsInMeleeRangeOnly, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                </StackPanel>
                 <CheckBox Margin="0,3,0,0" Content="Fleche" IsChecked="{Binding RedMageSettings.Fleche, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
             </StackPanel>
         </controls:SettingsBlock>


### PR DESCRIPTION
List of changes:
1. Hardcasts should no longer sneak in between Corps-a-corps and Riposte
2. Added a user option to enable Corps-a-corps only when in melee range.. This allows you to get the extra DPS from Corps, but without going zooming around the room unexpectedly.