### PR TITLE
RDM AoE improvements

### DIFF
--- a/Magitek/Logic/RedMage/Aoe.cs
+++ b/Magitek/Logic/RedMage/Aoe.cs
@@ -74,7 +74,8 @@ namespace Magitek.Logic.RedMage
                    BlackMana == 100
                 && WhiteMana == 100
                 && Spells.Embolden.Cooldown == TimeSpan.Zero
-                && RedMageSettings.Instance.Embolden;
+                && RedMageSettings.Instance.Embolden
+                && Core.Me.ClassLevel >= Spells.Embolden.LevelAcquired;
 
             bool burstEmboldenAndManaficationAt90 =
                    BlackMana >= 90
@@ -82,13 +83,16 @@ namespace Magitek.Logic.RedMage
                 && Spells.Manafication.Cooldown == TimeSpan.Zero
                 && Spells.Embolden.Cooldown == TimeSpan.Zero
                 && RedMageSettings.Instance.Manafication
-                && RedMageSettings.Instance.Embolden;
+                && RedMageSettings.Instance.Embolden
+                && Core.Me.ClassLevel >= Spells.Manafication.LevelAcquired
+                && Core.Me.ClassLevel >= Spells.Embolden.LevelAcquired;
 
             bool burstManaficationAt50 =
                    BlackMana >= 50
                 && WhiteMana >= 50
                 && Spells.Manafication.Cooldown == TimeSpan.Zero
-                && RedMageSettings.Instance.Manafication;
+                && RedMageSettings.Instance.Manafication
+                && Core.Me.ClassLevel >= Spells.Manafication.LevelAcquired;
 
             if (   enemiesInRange >= 3
                 && (   burstEmboldenAt100
@@ -140,16 +144,8 @@ namespace Magitek.Logic.RedMage
 
                 return true;
             }
-            //Only two enemies in range - just use Moulinet to prevent wasting mana
-            else if (BlackMana >= 90 && WhiteMana >= 90 && enemiesInRange == 2)
-            {
-                Logger.WriteInfo($"Burning one Moulinet to use excess mana ({enemiesInRange} enemies)");
-                return await Spells.Moulinet.Cast(Core.Me.CurrentTarget);
-            }
-            //Use a Moulinet so we don't waste mana while waiting for buffs to pop
-            else if (   BlackMana >= 90 && WhiteMana >= 90
-                     && enemiesInRange >= 3
-                     && Spells.Embolden.Cooldown != TimeSpan.Zero)
+            //Use Moulinet to prevent wasting mana
+            else if (BlackMana >= 90 && WhiteMana >= 90 && enemiesInRange >= 2)
             {
                 Logger.WriteInfo($"Burning one Moulinet to use excess mana ({enemiesInRange} enemies)");
                 return await Spells.Moulinet.Cast(Core.Me.CurrentTarget);

--- a/Magitek/Logic/RedMage/Aoe.cs
+++ b/Magitek/Logic/RedMage/Aoe.cs
@@ -43,6 +43,90 @@ namespace Magitek.Logic.RedMage
                 return await Spells.ContreSixte.Cast(Core.Me.CurrentTarget);
         }
 
+        public static int EnemiesInMeleeRange => Combat.Enemies.Count(r => r.InView() && r.Distance(Core.Me) <= 6 + r.CombatReach);
+
+        private static int EnemiesInMeleeRangeWith40PctHealth => Combat.Enemies.Count(r =>    r.InView()
+                                                                                           && r.Distance(Core.Me) <= 6 + r.CombatReach
+                                                                                           && r.CurrentHealthPercent >= RedMageSettings.Instance.EmboldenFinisherPercent);
+
+        //We don't want the single target swiftcast firing off when we're doing a Moulinet finisher
+        public static bool AllowSingleTargetSwiftcast => EnemiesInMeleeRange < RedMageSettings.Instance.MoulinetEnemies || EnemiesInMeleeRange == 1;
+
+        //TODO: Should we be trying to weave this?
+        //TODO: Should we only use this if the pack has a certain amount of health left?
+        public static async Task<bool> Embolden()
+        {
+            if (!RedMageSettings.Instance.UseMelee)
+                return false;
+
+            if (!RedMageSettings.Instance.Embolden)
+                return false;
+
+            if (Core.Me.ClassLevel < Spells.Embolden.LevelAcquired)
+                return false;
+
+            //We only use this in conjunction with Moulinet
+            if (EnemiesInMeleeRange < RedMageSettings.Instance.MoulinetEnemies)
+            return false;
+
+            //We only use this if enough enemies have enough health
+            if (EnemiesInMeleeRangeWith40PctHealth < 3)
+                return false;
+
+            if (BlackMana < 90 || WhiteMana < 90)
+                return false;
+
+            if (   BlackMana == 100
+                && WhiteMana == 100)
+            {
+                return await Spells.Embolden.Cast(Core.Me.CurrentTarget);
+            }
+
+            if (Core.Me.HasAura(Auras.Manafication))
+            {
+                return await Spells.Embolden.Cast(Core.Me.CurrentTarget);
+            }
+
+            if (   Spells.Manafication.Cooldown == TimeSpan.Zero
+                && RedMageSettings.Instance.Manafication
+                && Core.Me.ClassLevel >= Spells.Manafication.LevelAcquired)
+            {
+                return await Spells.Embolden.Cast(Core.Me.CurrentTarget);
+            }
+
+            return false;
+        }
+
+        //TODO: Should we be trying to weave this?
+        //TODO: Should we only use this if the pack has a certain amount of health left?
+        public static async Task<bool> Manafication()
+        {
+            if (!RedMageSettings.Instance.UseMelee)
+                return false;
+
+            if (!RedMageSettings.Instance.Manafication)
+                return false;
+
+            if (Core.Me.ClassLevel < Spells.Manafication.LevelAcquired)
+                return false;
+
+            //We only use this in conjunction with Moulinet
+            if (EnemiesInMeleeRange < RedMageSettings.Instance.MoulinetEnemies)
+                return false;
+
+            //We only use this if enough enemies have enough health
+            if (EnemiesInMeleeRangeWith40PctHealth < 3)
+                return false;
+
+            //Only use Manafication for AoE between 50 and 70 mana
+            if (    BlackMana < 50
+                ||  WhiteMana < 50
+                || (BlackMana > 70 && WhiteMana > 70))
+                return false;
+            else
+                return await Spells.Manafication.Cast(Core.Me);
+        }
+
         public static async Task<bool> Moulinet()
         {
             if (!RedMageSettings.Instance.UseMelee)
@@ -61,159 +145,29 @@ namespace Magitek.Logic.RedMage
             if (Core.Me.HasAura(Auras.Dualcast))
                 return false;
 
-            int enemiesInRange = Combat.Enemies.Count(r => r.InView() && r.Distance(Core.Me) <= 6 + r.CombatReach);
-
-            if (enemiesInRange < RedMageSettings.Instance.MoulinetEnemies)
+            if (EnemiesInMeleeRange < RedMageSettings.Instance.MoulinetEnemies)
                 return false;
 
-            //There are three conditions under which to do a big AoE Burst:
-            //  1. Mana is maxed and Embolden is up, in which case fire off Embolden and then Moulinet 5x
-            //  2. Mana is >90 and both Embolden and Manafication are up, in which case fire off Embolden, Moulinet 2x, Manafication, and then Moulinet 5x
-            //  3. Mana is >50 (but not too much) and Manafication is up, in which case fire off Manafication, Embolden if available, and then Moulinet 5x
-            bool burstEmboldenAt100 = 
-                   BlackMana == 100
-                && WhiteMana == 100
-                && Spells.Embolden.Cooldown == TimeSpan.Zero
-                && RedMageSettings.Instance.Embolden
-                && Core.Me.ClassLevel >= Spells.Embolden.LevelAcquired;
-
-            bool burstEmboldenAndManaficationAt90 =
-                   BlackMana >= 90
-                && WhiteMana >= 90
-                && Spells.Manafication.Cooldown == TimeSpan.Zero
-                && Spells.Embolden.Cooldown == TimeSpan.Zero
-                && RedMageSettings.Instance.Manafication
-                && RedMageSettings.Instance.Embolden
-                && Core.Me.ClassLevel >= Spells.Manafication.LevelAcquired;
-
-            bool burstManaficationAt50 =
-                   BlackMana >= 50
-                && WhiteMana >= 50
-                && Spells.Manafication.Cooldown == TimeSpan.Zero
-                && RedMageSettings.Instance.Manafication
-                && Core.Me.ClassLevel >= Spells.Manafication.LevelAcquired;
-
-            //No embolden yet, so use Moulinet if there are three enemies, or to burn mana if there are only 2
-            if (Core.Me.ClassLevel < Spells.Embolden.LevelAcquired)
+            if (EnemiesInMeleeRange >= 3
+                && Core.Me.ClassLevel < Spells.Embolden.LevelAcquired)
             {
-                if (enemiesInRange >= 3)
-                {
-                    Logger.WriteInfo($"Using one Moulinet because no buffs available at this level ({enemiesInRange} enemies)");
-                    return await Spells.Moulinet.Cast(Core.Me.CurrentTarget);
-                }
-                else if (enemiesInRange == 2 && BlackMana >= 90 && WhiteMana >= 90)
-                {
-                    Logger.WriteInfo($"Burning one Moulinet to use excess mana ({enemiesInRange} enemies)");
-                    return await Spells.Moulinet.Cast(Core.Me.CurrentTarget);
-                }
-            }
-            else if (   enemiesInRange >= 3
-                     && (   burstEmboldenAt100
-                         || burstEmboldenAndManaficationAt90
-                         || burstManaficationAt50)) //TODO: Should we delay this if embolden also up, or will be up soon?
-            {
-                if (burstEmboldenAndManaficationAt90)
-                {
-                    Logger.WriteInfo($"Bursting Moulinet 7x with Embolden and Manafication ({enemiesInRange} enemies)");
-                    SpellQueueLogic.SpellQueueReset(() => SpellQueueLogic.Timeout.ElapsedMilliseconds > 18000);
-                    Enqueue7MoulinetWithEmboldenAndManafication();
-                }
-                else if (burstEmboldenAt100)
-                {
-                    Logger.WriteInfo($"Bursting Moulinet with Embolden ({enemiesInRange} enemies)");
-                    SpellQueueLogic.SpellQueueReset(() => SpellQueueLogic.Timeout.ElapsedMilliseconds > 18000);
-                    EnqueueMoulinetWithEmbolden();
-                }
-                else //ManaficationAt50
-                {
-                    //If we'd be wasting some mana, Moulinet 1x and come around again
-                    if (BlackMana > 60 && WhiteMana > 60)
-                    {
-                        Logger.WriteInfo($"Burning one Moulinet to prepare for Manafication ({enemiesInRange} enemies)");
-                        return await Spells.Moulinet.Cast(Core.Me.CurrentTarget);
-                    }
-                    else
-                    {
-                        SpellQueueLogic.SpellQueueReset(() => SpellQueueLogic.Timeout.ElapsedMilliseconds > 18000);
-                        //Use Embolden if available
-                        if (Spells.Embolden.Cooldown == TimeSpan.Zero)
-                        {
-                            Logger.WriteInfo($"Bursting Moulinet 5x with Embolden and Manafication ({enemiesInRange} enemies)");
-                            Enqueue5MoulinetWithEmboldenAndManafication();
-                        }
-                        else
-                        {
-                            Logger.WriteInfo($"Bursting Moulinet with Manafication ({enemiesInRange} enemies)");
-                            EnqueueMoulinetWithManafication();
-                        }
-                    }
-                }
-
-                if (Spells.Swiftcast.Cooldown == TimeSpan.Zero && !Core.Me.HasAura(Auras.Swiftcast))
-                {
-                    SpellQueueLogic.SpellQueue.Enqueue(new QueueSpell { Spell = Spells.Swiftcast, TargetSelf = true, Wait = new QueueSpellWait() { Name = "Wait for Swiftcast", Check = () => ActionManager.CanCast(Spells.Swiftcast, null), WaitTime = 2500, EndQueueIfWaitFailed = true }, });
-                    SpellQueueLogic.SpellQueue.Enqueue(new QueueSpell { Spell = Spells.Impact, Wait = new QueueSpellWait() { Name = "Wait for Impact", Check = () => ActionManager.CanCast(Spells.Impact, null), WaitTime = 2500, EndQueueIfWaitFailed = true }, });
-                }
-
-                return true;
-            }
-            //Only two enemies in range - just use Moulinet to prevent wasting mana
-            else if (BlackMana >= 90 && WhiteMana >= 90 && enemiesInRange == 2)
-            {
-                Logger.WriteInfo($"Burning one Moulinet to use excess mana ({enemiesInRange} enemies)");
                 return await Spells.Moulinet.Cast(Core.Me.CurrentTarget);
             }
-            //Use a Moulinet so we don't waste mana while waiting for buffs to pop
-            else if (   BlackMana >= 90 && WhiteMana >= 90
-                     && enemiesInRange >= 3
-                     && Spells.Embolden.Cooldown != TimeSpan.Zero)
+
+            if (   EnemiesInMeleeRange >= 1
+                && (Core.Me.HasAura(Auras.Embolden) || Core.Me.HasAura(Auras.Manafication)))
             {
-                Logger.WriteInfo($"Burning one Moulinet to use excess mana ({enemiesInRange} enemies)");
                 return await Spells.Moulinet.Cast(Core.Me.CurrentTarget);
             }
-            //Use a Moulinet immediately if any of our buffs are still up outside the burst
-            else if (   enemiesInRange >= 3
-                     && (Core.Me.HasAura(Auras.Manafication) || Core.Me.Auras.Any(aura => aura.Name == "Embolden")))
+
+            if (EnemiesInMeleeRange >= 1
+                && BlackMana >= 90
+                && WhiteMana >= 90)
             {
-                Logger.WriteInfo($"Using one Moulinet because buffs are up ({enemiesInRange} enemies)");
                 return await Spells.Moulinet.Cast(Core.Me.CurrentTarget);
             }
 
             return false;
-        }
-
-        private static void Enqueue7MoulinetWithEmboldenAndManafication()
-        {
-            SpellQueueLogic.SpellQueue.Enqueue(new QueueSpell { Spell = Spells.Embolden, TargetSelf = true, Wait = new QueueSpellWait() { Name = "Wait for Embolden", Check = () => ActionManager.CanCast(Spells.Embolden, null), WaitTime = 2500, EndQueueIfWaitFailed = true }, });
-            SpellQueueLogic.SpellQueue.Enqueue(new QueueSpell { Spell = Spells.Moulinet, Wait = new QueueSpellWait() { Name = "Wait for Pre-Manafication Moulinet 1", Check = () => ActionManager.CanCast(Spells.Moulinet, null), WaitTime = 2500, EndQueueIfWaitFailed = true }, });
-            SpellQueueLogic.SpellQueue.Enqueue(new QueueSpell { Spell = Spells.Moulinet, Wait = new QueueSpellWait() { Name = "Wait for Pre-Manafication Moulinet 2", Check = () => ActionManager.CanCast(Spells.Moulinet, null), WaitTime = 2500, EndQueueIfWaitFailed = true }, });
-            EnqueueMoulinetWithManafication();
-        }
-
-        private static void Enqueue5MoulinetWithEmboldenAndManafication()
-        {
-            SpellQueueLogic.SpellQueue.Enqueue(new QueueSpell { Spell = Spells.Embolden, TargetSelf = true, Wait = new QueueSpellWait() { Name = "Wait for Embolden", Check = () => ActionManager.CanCast(Spells.Embolden, null), WaitTime = 2500, EndQueueIfWaitFailed = true }, });
-            EnqueueMoulinetWithManafication();
-        }
-
-        private static void EnqueueMoulinetWithEmbolden()
-        {
-            SpellQueueLogic.SpellQueue.Enqueue(new QueueSpell { Spell = Spells.Embolden, TargetSelf = true, Wait = new QueueSpellWait() { Name = "Wait for Embolden", Check = () => ActionManager.CanCast(Spells.Embolden, null), WaitTime = 2500, EndQueueIfWaitFailed = true }, });
-            SpellQueueLogic.SpellQueue.Enqueue(new QueueSpell { Spell = Spells.Moulinet, Wait = new QueueSpellWait() { Name = "Wait for Moulinet 1", Check = () => ActionManager.CanCast(Spells.Moulinet, null), WaitTime = 2500, EndQueueIfWaitFailed = true }, });
-            SpellQueueLogic.SpellQueue.Enqueue(new QueueSpell { Spell = Spells.Moulinet, Wait = new QueueSpellWait() { Name = "Wait for Moulinet 2", Check = () => ActionManager.CanCast(Spells.Moulinet, null), WaitTime = 2500, EndQueueIfWaitFailed = true }, });
-            SpellQueueLogic.SpellQueue.Enqueue(new QueueSpell { Spell = Spells.Moulinet, Wait = new QueueSpellWait() { Name = "Wait for Moulinet 3", Check = () => ActionManager.CanCast(Spells.Moulinet, null), WaitTime = 2500, EndQueueIfWaitFailed = true }, });
-            SpellQueueLogic.SpellQueue.Enqueue(new QueueSpell { Spell = Spells.Moulinet, Wait = new QueueSpellWait() { Name = "Wait for Moulinet 4", Check = () => ActionManager.CanCast(Spells.Moulinet, null), WaitTime = 2500, EndQueueIfWaitFailed = true }, });
-            SpellQueueLogic.SpellQueue.Enqueue(new QueueSpell { Spell = Spells.Moulinet, Wait = new QueueSpellWait() { Name = "Wait for Moulinet 5", Check = () => ActionManager.CanCast(Spells.Moulinet, null), WaitTime = 2500, EndQueueIfWaitFailed = true }, });
-        }
-
-        private static void EnqueueMoulinetWithManafication()
-        {
-            SpellQueueLogic.SpellQueue.Enqueue(new QueueSpell { Spell = Spells.Manafication, TargetSelf = true, Wait = new QueueSpellWait() { Name = "Wait for Manafication", Check = () => ActionManager.CanCast(Spells.Manafication, null), WaitTime = 2500, EndQueueIfWaitFailed = true }, });
-            SpellQueueLogic.SpellQueue.Enqueue(new QueueSpell { Spell = Spells.Moulinet, Wait = new QueueSpellWait() { Name = "Wait for Moulinet 1", Check = () => ActionManager.CanCast(Spells.Moulinet, null), WaitTime = 2500, EndQueueIfWaitFailed = true }, });
-            SpellQueueLogic.SpellQueue.Enqueue(new QueueSpell { Spell = Spells.Moulinet, Wait = new QueueSpellWait() { Name = "Wait for Moulinet 2", Check = () => ActionManager.CanCast(Spells.Moulinet, null), WaitTime = 2500, EndQueueIfWaitFailed = true }, });
-            SpellQueueLogic.SpellQueue.Enqueue(new QueueSpell { Spell = Spells.Moulinet, Wait = new QueueSpellWait() { Name = "Wait for Moulinet 3", Check = () => ActionManager.CanCast(Spells.Moulinet, null), WaitTime = 2500, EndQueueIfWaitFailed = true }, });
-            SpellQueueLogic.SpellQueue.Enqueue(new QueueSpell { Spell = Spells.Moulinet, Wait = new QueueSpellWait() { Name = "Wait for Moulinet 4", Check = () => ActionManager.CanCast(Spells.Moulinet, null), WaitTime = 2500, EndQueueIfWaitFailed = true }, });
-            SpellQueueLogic.SpellQueue.Enqueue(new QueueSpell { Spell = Spells.Moulinet, Wait = new QueueSpellWait() { Name = "Wait for Moulinet 5", Check = () => ActionManager.CanCast(Spells.Moulinet, null), WaitTime = 2500, EndQueueIfWaitFailed = true }, });
         }
 
         public static async Task<bool> Veraero2()

--- a/Magitek/Logic/RedMage/SingleTarget.cs
+++ b/Magitek/Logic/RedMage/SingleTarget.cs
@@ -97,6 +97,11 @@ namespace Magitek.Logic.RedMage
                     if (!RedMageRoutines.CanWeave)
                         return false;
 
+                    if (!Aoe.AllowSingleTargetSwiftcast) //We don't want to use this when we're in our AoE rotation
+                        return false;
+
+                    //TODO: This can still sneak in between Corps-a-corps and Riposte. Figure out why and add a check here.
+
                     if (await Spells.Swiftcast.Cast(Core.Me))
                     {
                         await Coroutine.Wait(2000, () => Core.Me.HasAura(Auras.Swiftcast));
@@ -136,6 +141,11 @@ namespace Magitek.Logic.RedMage
 
                     if (!RedMageRoutines.CanWeave)
                         return false;
+
+                    if (!Aoe.AllowSingleTargetSwiftcast) //We don't want to use this when we're in our AoE rotation
+                        return false;
+
+                    //TODO: This can still sneak in between Corps-a-corps and Riposte. Figure out why and add a check here.
 
                     if (await Spells.Swiftcast.Cast(Core.Me))
                     {

--- a/Magitek/Models/RedMage/RedMageSettings.cs
+++ b/Magitek/Models/RedMage/RedMageSettings.cs
@@ -63,6 +63,10 @@ namespace Magitek.Models.RedMage
         public int MoulinetEnemies { get; set; }
 
         [Setting]
+        [DefaultValue(40)]
+        public int EmboldenFinisherPercent { get; set; }
+
+        [Setting]
         [DefaultValue(true)]
         public bool UseContreSixte { get; set; }
 

--- a/Magitek/Rotations/RedMage.cs
+++ b/Magitek/Rotations/RedMage.cs
@@ -78,10 +78,6 @@ namespace Magitek.Rotations
                 }
             }
 
-            if (SpellQueueLogic.SpellQueue.Any()) if (await SpellQueueLogic.SpellQueueMethod()) return true;
-
-            if (await Buff.Embolden()) return true;
-            if (await Buff.Manafication()) return true;
             if (await Buff.LucidDreaming()) return true;
 
             if (RedMageRoutines.CanWeave)
@@ -92,11 +88,16 @@ namespace Magitek.Rotations
 
             if (RedMageSettings.Instance.UseAoe)
             {
+                if (await Aoe.Embolden()) return true;
+                if (await Aoe.Manafication()) return true;
                 if (await Aoe.Moulinet()) return true;
                 if (await Aoe.Scatter()) return true;
                 if (await Aoe.Veraero2()) return true;
                 if (await Aoe.Verthunder2()) return true;
             }
+
+            if (await Buff.Embolden()) return true;
+            if (await Buff.Manafication()) return true;
 
             if (await SingleTarget.CorpsACorps()) return true;
 

--- a/Magitek/Utilities/Auras.cs
+++ b/Magitek/Utilities/Auras.cs
@@ -211,7 +211,7 @@ namespace Magitek.Utilities
             EverlastingFlight = 2030,
             Acceleration = 1238,
             Divination = 2034,
-            Embolden = 2282,
+            Embolden = 1239,
             MeditationSAM = 2176,
             OffGuard = 1717,
             Bleeding = 1714,

--- a/Magitek/Views/UserControls/RedMage/Aoe.xaml
+++ b/Magitek/Views/UserControls/RedMage/Aoe.xaml
@@ -49,6 +49,14 @@
             </StackPanel>
         </controls:SettingsBlock>
 
+        <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
+            <StackPanel Margin="5" Orientation="Horizontal">
+                <TextBlock Style="{DynamicResource TextBlockDefault}" Text="Enemy Health at Least " />
+                <controls:Numeric MaxValue="100" MinValue="1" Value="{Binding RedMageSettings.EmboldenFinisherPercent, Mode=TwoWay}" />
+                <TextBlock Style="{DynamicResource TextBlockDefault}" Text=" Percent for Embolden+Moulinet Finisher" />
+            </StackPanel>
+        </controls:SettingsBlock>
+
     </StackPanel>
 
 </UserControl>


### PR DESCRIPTION
- Redesigned RDM AoE burst to use the standard priority-based approach, instead of the spell queue. Should be more responsive to changing conditions.
- Added setting for minimum enemy health percentage before starting AoE burst
- Fixed AoE burst handling for RDM levels 52-57