### PR TITLE
RDM: Added option to swiftcast Scatter

### DIFF
--- a/Magitek/Logic/RedMage/Aoe.cs
+++ b/Magitek/Logic/RedMage/Aoe.cs
@@ -206,7 +206,8 @@ namespace Magitek.Logic.RedMage
 
         public static async Task<bool> Verthunder2()
         {
-            if (BlackMana > WhiteMana)
+            //We're willing to go unbalanced if we don't have Veraero2 yet
+            if (BlackMana > WhiteMana && Core.Me.ClassLevel >= Spells.Veraero2.LevelAcquired)
                 return false;
 
             if (!RedMageSettings.Instance.Ver2)

--- a/Magitek/Logic/RedMage/Aoe.cs
+++ b/Magitek/Logic/RedMage/Aoe.cs
@@ -3,10 +3,11 @@ using System.Linq;
 using System.Threading.Tasks;
 using ff14bot;
 using ff14bot.Managers;
+using Buddy.Coroutines;
 using Magitek.Extensions;
 using Magitek.Models.RedMage;
 using Magitek.Utilities;
-using Magitek.Models.QueueSpell;
+using RedMageRoutines = Magitek.Utilities.Routines.RedMage;
 using static ff14bot.Managers.ActionResourceManager.RedMage;
 
 namespace Magitek.Logic.RedMage
@@ -18,14 +19,35 @@ namespace Magitek.Logic.RedMage
             if (!RedMageSettings.Instance.Scatter)
                 return false;
 
-            if (!Core.Me.HasAura(Auras.Dualcast))
-                return false;
-
             if (Core.Me.CurrentTarget.EnemiesNearby(5).Count() < RedMageSettings.Instance.ScatterEnemies)
                 return false;
 
-            else
-                return await Spells.Scatter.Cast(Core.Me.CurrentTarget);
+            if (!Core.Me.HasAura(Auras.Dualcast))
+            {
+                //TODO: The Balance says for single target, we should hold this for when we're moving around. Is that true for AoE too?
+                if (RedMageSettings.Instance.SwiftcastScatter)
+                {
+                    if (!ActionManager.HasSpell(Spells.Swiftcast.Id))
+                        return false;
+
+                    if (Spells.Swiftcast.Cooldown != TimeSpan.Zero)
+                        return false;
+
+                    if (!RedMageRoutines.CanWeave)
+                        return false;
+
+                    if (await Spells.Swiftcast.Cast(Core.Me))
+                    {
+                        await Coroutine.Wait(2000, () => Core.Me.HasAura(Auras.Swiftcast));
+                        await Coroutine.Wait(2000, () => ActionManager.CanCast(Spells.Scatter, Core.Me.CurrentTarget));
+                        return await Spells.Scatter.Cast(Core.Me.CurrentTarget);
+                    }
+                }
+                else
+                    return false;
+            }
+
+            return await Spells.Scatter.Cast(Core.Me.CurrentTarget);
         }
 
         public static async Task<bool> ContreSixte()
@@ -48,9 +70,6 @@ namespace Magitek.Logic.RedMage
         private static int EnemiesInMeleeRangeWith40PctHealth => Combat.Enemies.Count(r =>    r.InView()
                                                                                            && r.Distance(Core.Me) <= 6 + r.CombatReach
                                                                                            && r.CurrentHealthPercent >= RedMageSettings.Instance.EmboldenFinisherPercent);
-
-        //We don't want the single target swiftcast firing off when we're doing a Moulinet finisher
-        public static bool AllowSingleTargetSwiftcast => EnemiesInMeleeRange < RedMageSettings.Instance.MoulinetEnemies || EnemiesInMeleeRange == 1;
 
         //TODO: Should we be trying to weave this?
         //TODO: Should we only use this if the pack has a certain amount of health left?

--- a/Magitek/Logic/RedMage/SingleTarget.cs
+++ b/Magitek/Logic/RedMage/SingleTarget.cs
@@ -17,6 +17,11 @@ namespace Magitek.Logic.RedMage
 {
     internal static class SingleTarget
     {
+        private static bool InMeleeRange => Core.Me.CurrentTarget.Distance(Core.Me) <= (4 + Core.Me.CurrentTarget.CombatReach);
+
+        //If we're further out than this, we don't want to zoom in, because we might run into some AoE
+        private static bool InSafeCorpsACorpsRange => Core.Me.CurrentTarget.Distance(Core.Me) <= (2 + Core.Me.CurrentTarget.CombatReach);
+
         public static async Task<bool> Jolt()
         {
             if (Core.Me.ClassLevel < 4)
@@ -97,10 +102,7 @@ namespace Magitek.Logic.RedMage
                     if (!RedMageRoutines.CanWeave)
                         return false;
 
-                    if (!Aoe.AllowSingleTargetSwiftcast) //We don't want to use this when we're in our AoE rotation
-                        return false;
-
-                    //TODO: This can still sneak in between Corps-a-corps and Riposte. Figure out why and add a check here.
+                    //TODO: I think I've seen this still sneak in between Corps-a-corps and Riposte. Figure out why and add a check here.
 
                     if (await Spells.Swiftcast.Cast(Core.Me))
                     {
@@ -142,10 +144,7 @@ namespace Magitek.Logic.RedMage
                     if (!RedMageRoutines.CanWeave)
                         return false;
 
-                    if (!Aoe.AllowSingleTargetSwiftcast) //We don't want to use this when we're in our AoE rotation
-                        return false;
-
-                    //TODO: This can still sneak in between Corps-a-corps and Riposte. Figure out why and add a check here.
+                    //TODO: I think I've seen this still sneak in between Corps-a-corps and Riposte. Figure out why and add a check here.
 
                     if (await Spells.Swiftcast.Cast(Core.Me))
                     {
@@ -307,14 +306,12 @@ namespace Magitek.Logic.RedMage
             //         When in Corps-a-corps-anywhere mode, it will be used only to open a combo. Great
             //         for getting into melee range quickly to get off a combo, but is dangerous for a
             //         lot of fights
-            if (   (RedMageSettings.Instance.CorpsACorpsInMeleeRangeOnly && !InMeleeRange)
+            if (   (RedMageSettings.Instance.CorpsACorpsInMeleeRangeOnly && !InSafeCorpsACorpsRange)
                 || (!RedMageSettings.Instance.CorpsACorpsInMeleeRangeOnly && !ReadyForCombo))
                 return false;
             else
                 return await Spells.CorpsACorps.Cast(Core.Me.CurrentTarget);
         }
-
-        private static bool InMeleeRange => Core.Me.CurrentTarget.Distance(Core.Me) <= (4 + Core.Me.CurrentTarget.CombatReach);
 
         public static async Task<bool> Zwerchhau()
         {

--- a/Magitek/Models/RedMage/RedMageSettings.cs
+++ b/Magitek/Models/RedMage/RedMageSettings.cs
@@ -32,6 +32,10 @@ namespace Magitek.Models.RedMage
 
         [Setting]
         [DefaultValue(true)]
+        public bool SwiftcastScatter { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
         public bool Acceleration { get; set; }
 
         [Setting]

--- a/Magitek/Utilities/Routines/RedMage.cs
+++ b/Magitek/Utilities/Routines/RedMage.cs
@@ -4,6 +4,7 @@ namespace Magitek.Utilities.Routines
 {
     internal static class RedMage
     {
+        //TODO: Can we take lag into account here?
         public static bool CanWeave => Spells.Riposte.Cooldown.TotalMilliseconds >= 700;
     }
 }

--- a/Magitek/Views/UserControls/RedMage/Aoe.xaml
+++ b/Magitek/Views/UserControls/RedMage/Aoe.xaml
@@ -33,11 +33,17 @@
             </StackPanel>
         </controls:SettingsBlock>
 
-        <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
-            <StackPanel Margin="5" Orientation="Horizontal">
+        <controls:SettingsBlock Margin="0,5,0,0" Background="{DynamicResource ClassSelectorBackground}">
+            <StackPanel Margin="5,5,5,0" Orientation="Horizontal">
                 <CheckBox Content="Scatter When There Are " IsChecked="{Binding RedMageSettings.Scatter, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                 <controls:Numeric MaxValue="100" MinValue="1" Value="{Binding RedMageSettings.ScatterEnemies, Mode=TwoWay}" />
                 <TextBlock Style="{DynamicResource TextBlockDefault}" Text=" Enemies In Range" />
+            </StackPanel>
+        </controls:SettingsBlock>
+
+        <controls:SettingsBlock Margin="0,0,0,5" Background="{DynamicResource ClassSelectorBackground}">
+            <StackPanel Margin="24,0,5,5" Orientation="Horizontal">
+                <CheckBox Content="Swiftcast Scatter" IsChecked="{Binding RedMageSettings.SwiftcastScatter, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
             </StackPanel>
         </controls:SettingsBlock>
 


### PR DESCRIPTION
- Added user option to use Swiftcast with Scatter when appropriate
- Corps-a-corps, when restricted to melee-range-only, now requires you to be a bit closer, to avoid jumping into close-range AoE
- Updated low-level AoE rotation to always cast Verthunder2 if Veraero2 isn't yet available, even if it will unbalance mana