### PR TITLE
In instances, track all enemies, whether tagged or not

### DIFF
--- a/Magitek/Utilities/Tracking.cs
+++ b/Magitek/Utilities/Tracking.cs
@@ -23,20 +23,28 @@ namespace Magitek.Utilities
         {
             UpdateCurrentPosition();
 
-            //In a Party
-            if (Globals.InParty)
+            if (Globals.InActiveDuty)
             {
-                _enemyCache = Globals.InActiveDuty
-                    // In a Party And an Instance
-                    ? GameObjectManager.GetObjectsOfType<BattleCharacter>().Where(r => r.TaggerType > 0 || r.IsBoss()).ToList()
-                    // In Party But OpenWorld, everything our Party tagged or every Fate Mob that is tagged by a Player
-                    : GameObjectManager.GetObjectsOfType<BattleCharacter>().Where(r => r.TaggerType == 2 || r.IsFate && r.TaggerType > 0 && !GameObjectManager.GetObjectsOfType<BattleCharacter>().Any(x => x.IsNpc && x.ObjectId == r.TaggerObjectId)).ToList();
+                //In an instance
+                //Use every enemy
+                _enemyCache = GameObjectManager.GetObjectsOfType<BattleCharacter>().ToList();
             }
             else
             {
-                // Not in a Party, use Attacker List combined with every Fate Mob that is tagged by a Player
-                var _fateEnemyCache = GameObjectManager.GetObjectsOfType<BattleCharacter>().Where(r => r.IsFate && r.TaggerType > 0 && !GameObjectManager.GetObjectsOfType<BattleCharacter>().Any(x => x.IsNpc && x.ObjectId == r.TaggerObjectId));
-                _enemyCache = GameObjectManager.Attackers.Union(_fateEnemyCache).ToList();
+                if (Globals.InParty)
+                {
+                    //In the open world, in a party
+                    //Use everything our party tagged or every Fate Mob that is tagged by a player
+                    _enemyCache = GameObjectManager.GetObjectsOfType<BattleCharacter>().Where(r => r.TaggerType == 2 || r.IsFate && r.TaggerType > 0 && !GameObjectManager.GetObjectsOfType<BattleCharacter>().Any(x => x.IsNpc && x.ObjectId == r.TaggerObjectId))
+                                                                                       .ToList();
+                }
+                else
+                {
+                    //In the open world, not in a party
+                    //Use attacker list combined with every Fate Mob that is tagged by a player
+                    var _fateEnemyCache = GameObjectManager.GetObjectsOfType<BattleCharacter>().Where(r => r.IsFate && r.TaggerType > 0 && !GameObjectManager.GetObjectsOfType<BattleCharacter>().Any(x => x.IsNpc && x.ObjectId == r.TaggerObjectId));
+                    _enemyCache = GameObjectManager.Attackers.Union(_fateEnemyCache).ToList();
+                }
             }
 
             Combat.Enemies.Clear();

--- a/Magitek/Utilities/Tracking.cs
+++ b/Magitek/Utilities/Tracking.cs
@@ -25,23 +25,32 @@ namespace Magitek.Utilities
 
             if (Globals.InActiveDuty)
             {
-                //In an instance
-                //Use every enemy
-                _enemyCache = GameObjectManager.GetObjectsOfType<BattleCharacter>().ToList();
+                if (BotManager.Current.IsAutonomous)
+                {
+                    //In an instance, autonomous
+                    //We should be a little less aggressive than if we're human-controlled, so just track attackers
+                    _enemyCache = GameObjectManager.Attackers.ToList();
+                }
+                else
+                {
+                    //In an instance, not autonomous
+                    //Track every enemy
+                    _enemyCache = GameObjectManager.GetObjectsOfType<BattleCharacter>().ToList();
+                }
             }
             else
             {
                 if (Globals.InParty)
                 {
                     //In the open world, in a party
-                    //Use everything our party tagged or every Fate Mob that is tagged by a player
+                    //Track everything our party tagged or every Fate Mob that is tagged by a player
                     _enemyCache = GameObjectManager.GetObjectsOfType<BattleCharacter>().Where(r => r.TaggerType == 2 || r.IsFate && r.TaggerType > 0 && !GameObjectManager.GetObjectsOfType<BattleCharacter>().Any(x => x.IsNpc && x.ObjectId == r.TaggerObjectId))
                                                                                        .ToList();
                 }
                 else
                 {
                     //In the open world, not in a party
-                    //Use attacker list combined with every Fate Mob that is tagged by a player
+                    //Track the attacker list combined with every Fate Mob that is tagged by a player
                     var _fateEnemyCache = GameObjectManager.GetObjectsOfType<BattleCharacter>().Where(r => r.IsFate && r.TaggerType > 0 && !GameObjectManager.GetObjectsOfType<BattleCharacter>().Any(x => x.IsNpc && x.ObjectId == r.TaggerObjectId));
                     _enemyCache = GameObjectManager.Attackers.Union(_fateEnemyCache).ToList();
                 }


### PR DESCRIPTION
In a dungeon, Magitek will frequently cast single-target spells at groups until everything's tagged. This will make it more aggressive - it should cast AoE at all groups now, whether tagged or not.
This change should have no effect in autonomous mode - manual-mode only.