### PR TITLE
RDM: Prevent Swiftcast from interrupting combo

### DIFF
--- a/Magitek/Logic/RedMage/SingleTarget.cs
+++ b/Magitek/Logic/RedMage/SingleTarget.cs
@@ -47,8 +47,8 @@ namespace Magitek.Logic.RedMage
 
         private static List<SpellData> ComboInProgressSpells = new List<SpellData>() { Spells.Riposte, Spells.Zwerchhau, Spells.EnchantedRedoublement, Spells.Verflare, Spells.Verholy };
         //Sometimes, after casting Riposte, the ActionManager still reports the spell *before* Riposte as the LastSpell, so we need to check the Casting class as well, just to be sure
-        public static bool ComboInProgress => ComboInProgressSpells.Any(   spell => spell.Id == ActionManager.LastSpellId
-                                                                        || spell.Id == Casting.LastSpell.Id);
+        public static bool ComboInProgress => ComboInProgressSpells.Any(spell =>    spell.Id == ActionManager.LastSpellId
+                                                                                 || spell.Id == Casting.LastSpell?.Id);
 
         //We should cast Veraero if we're holding for Veraero, OR if we have less white mana and we're not holding for Verthunder
         private static bool ShouldCastVeraero =>
@@ -104,8 +104,6 @@ namespace Magitek.Logic.RedMage
                     if (!RedMageRoutines.CanWeave)
                         return false;
 
-                    //TODO: I think I've seen this still sneak in between Corps-a-corps and Riposte. Figure out why and add a check here.
-
                     if (await Spells.Swiftcast.Cast(Core.Me))
                     {
                         await Coroutine.Wait(2000, () => Core.Me.HasAura(Auras.Swiftcast));
@@ -145,8 +143,6 @@ namespace Magitek.Logic.RedMage
 
                     if (!RedMageRoutines.CanWeave)
                         return false;
-
-                    //TODO: I think I've seen this still sneak in between Corps-a-corps and Riposte. Figure out why and add a check here.
 
                     if (await Spells.Swiftcast.Cast(Core.Me))
                     {

--- a/Magitek/Logic/RedMage/SingleTarget.cs
+++ b/Magitek/Logic/RedMage/SingleTarget.cs
@@ -46,7 +46,9 @@ namespace Magitek.Logic.RedMage
         }
 
         private static List<SpellData> ComboInProgressSpells = new List<SpellData>() { Spells.Riposte, Spells.Zwerchhau, Spells.EnchantedRedoublement, Spells.Verflare, Spells.Verholy };
-        public static bool ComboInProgress => ComboInProgressSpells.Any(spell => spell.Id == ActionManager.LastSpellId);
+        //Sometimes, after casting Riposte, the ActionManager still reports the spell *before* Riposte as the LastSpell, so we need to check the Casting class as well, just to be sure
+        public static bool ComboInProgress => ComboInProgressSpells.Any(   spell => spell.Id == ActionManager.LastSpellId
+                                                                        || spell.Id == Casting.LastSpell.Id);
 
         //We should cast Veraero if we're holding for Veraero, OR if we have less white mana and we're not holding for Verthunder
         private static bool ShouldCastVeraero =>


### PR DESCRIPTION
Occasionally, the RDM routine will cast Swiftcast immediately after Riposte, thus interrupting the combo. This appears to be due to ActionManager.LastSpellId lagging a little, and not reflecting that Riposte was cast until it's too late. Now we also check Casting.LastSpell, to be sure.