### PR TITLE
Interrupt & stun improvements

### DIFF
--- a/Magitek/Logic/BlackMage/Buff.cs
+++ b/Magitek/Logic/BlackMage/Buff.cs
@@ -154,7 +154,7 @@ namespace Magitek.Logic.BlackMage
                 return await Spells.ManaFont.Cast(Core.Me);
 
             if (Casting.LastSpell == Spells.Fire3
-                && Spells.Fire.Cooldown.TotalMilliseconds > 700)
+                && Spells.Fire.Cooldown.TotalMilliseconds > Globals.AnimationLockMs)
                 return await Spells.ManaFont.Cast(Core.Me);
 
             return false;

--- a/Magitek/Logic/Paladin/SingleTarget.cs
+++ b/Magitek/Logic/Paladin/SingleTarget.cs
@@ -112,6 +112,7 @@ namespace Magitek.Logic.Paladin
                     stunTarget = GameObjectManager.Attackers.Where(r =>    r.IsBoss()
                                                                         && r.InView()
                                                                         && r.IsCasting
+                                                                        && StunTracker.IsStunnable(r)
                                                                         && r.SpellCastInfo.RemainingCastTime.TotalMilliseconds >= minimumMsLeftOnEnemyCast)
                                                             .OrderBy(r => r.SpellCastInfo.RemainingCastTime)
                                                             .FirstOrDefault();
@@ -119,13 +120,19 @@ namespace Magitek.Logic.Paladin
                     if (stunTarget == null)
                         return false;
 
-                    return await Spells.ShieldBash.Cast(stunTarget);
+                    if (await Spells.ShieldBash.Cast(stunTarget))
+                    {
+                        StunTracker.RecordAttemptedStun(stunTarget);
+                        return true;
+                    }
 
+                    return false;
 
                 case InterruptStrategy.AlwaysInterrupt:
                     stunTarget =
                         Combat.Enemies.Where(r =>    r.InView()
                                                   && r.IsCasting
+                                                  && StunTracker.IsStunnable(r)
                                                   && r.SpellCastInfo.RemainingCastTime.TotalMilliseconds > minimumMsLeftOnEnemyCast)
                                       .OrderBy(r => r.SpellCastInfo.RemainingCastTime)
                                       .FirstOrDefault();
@@ -133,7 +140,13 @@ namespace Magitek.Logic.Paladin
                     if (stunTarget == null)
                         return false;
 
-                    return await Spells.ShieldBash.Cast(stunTarget);
+                    if (await Spells.ShieldBash.Cast(stunTarget))
+                    {
+                        StunTracker.RecordAttemptedStun(stunTarget);
+                        return true;
+                    }
+
+                    return false;
 
                 default:
                     return false;

--- a/Magitek/Logic/Roles/Tank.cs
+++ b/Magitek/Logic/Roles/Tank.cs
@@ -3,9 +3,11 @@ using ff14bot.Managers;
 using ff14bot.Objects;
 using Magitek.Enumerations;
 using Magitek.Extensions;
+using Magitek.Models.Account;
 using Magitek.Models.Roles;
 using Magitek.Utilities;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Auras = Magitek.Utilities.Auras;
@@ -69,6 +71,13 @@ namespace Magitek.Logic.Roles
             if (!settings.UseInterrupt)
                 return false;
 
+            //The amount of time before our interrupt will go off
+            int minimumMsLeftOnEnemyCast =   BaseSettings.Instance.UserLatencyOffset
+                                           + Globals.AnimationLockMs
+                                           + Casting.SpellCastHistory.LastOrDefault()?.AnimationLockRemainingMs ?? 0;
+
+            IEnumerable<BattleCharacter> castingEnemies;
+            BattleCharacter stunTarget;
             BattleCharacter interruptTarget;
 
             switch (settings.Strategy)
@@ -77,27 +86,39 @@ namespace Magitek.Logic.Roles
                     return false;
 
                 case InterruptStrategy.InterruptOnlyBosses:
-                    interruptTarget = GameObjectManager.Attackers.FirstOrDefault(r =>
-                        r.IsBoss() && r.InView() && r.IsCasting && r.SpellCastInfo.Interruptible);
+                    castingEnemies = GameObjectManager.Attackers.Where(r =>    r.IsBoss()
+                                                                            && r.InView()
+                                                                            && r.IsCasting
+                                                                            && r.SpellCastInfo.RemainingCastTime.TotalMilliseconds >= minimumMsLeftOnEnemyCast)
+                                                                .OrderBy(r => r.SpellCastInfo.RemainingCastTime);
 
-                    if (interruptTarget == null)
+                    stunTarget = castingEnemies.FirstOrDefault();
+
+                    if (stunTarget == null)
                         return false;
 
-                    if (await Spells.LowBlow.Cast(interruptTarget))
+                    if (await Spells.LowBlow.Cast(stunTarget))
                         return true;
+
+                    interruptTarget = castingEnemies.FirstOrDefault(r => r.SpellCastInfo.Interruptible);
 
                     return await Spells.Interject.Cast(interruptTarget);
 
-
                 case InterruptStrategy.AlwaysInterrupt:
-                    interruptTarget =
-                        Combat.Enemies.FirstOrDefault(r => r.InView() && r.IsCasting && r.SpellCastInfo.Interruptible);
+                    castingEnemies = Combat.Enemies.Where(r =>    r.InView() 
+                                                               && r.IsCasting
+                                                               && r.SpellCastInfo.RemainingCastTime.TotalMilliseconds >= minimumMsLeftOnEnemyCast)
+                                                   .OrderBy(r => r.SpellCastInfo.RemainingCastTime);
 
-                    if (interruptTarget == null)
+                    stunTarget = castingEnemies.FirstOrDefault();
+
+                    if (stunTarget == null)
                         return false;
 
-                    if (await Spells.LowBlow.Cast(interruptTarget))
+                    if (await Spells.LowBlow.Cast(stunTarget))
                         return true;
+
+                    interruptTarget = castingEnemies.FirstOrDefault(r => r.SpellCastInfo.Interruptible);
 
                     return await Spells.Interject.Cast(interruptTarget);
 

--- a/Magitek/Logic/Roles/Tank.cs
+++ b/Magitek/Logic/Roles/Tank.cs
@@ -92,13 +92,16 @@ namespace Magitek.Logic.Roles
                                                                             && r.SpellCastInfo.RemainingCastTime.TotalMilliseconds >= minimumMsLeftOnEnemyCast)
                                                                 .OrderBy(r => r.SpellCastInfo.RemainingCastTime);
 
-                    stunTarget = castingEnemies.FirstOrDefault();
+                    stunTarget = castingEnemies.FirstOrDefault(r => StunTracker.IsStunnable(r));
 
                     if (stunTarget == null)
                         return false;
 
                     if (await Spells.LowBlow.Cast(stunTarget))
+                    {
+                        StunTracker.RecordAttemptedStun(stunTarget);
                         return true;
+                    }
 
                     interruptTarget = castingEnemies.FirstOrDefault(r => r.SpellCastInfo.Interruptible);
 
@@ -110,13 +113,16 @@ namespace Magitek.Logic.Roles
                                                                && r.SpellCastInfo.RemainingCastTime.TotalMilliseconds >= minimumMsLeftOnEnemyCast)
                                                    .OrderBy(r => r.SpellCastInfo.RemainingCastTime);
 
-                    stunTarget = castingEnemies.FirstOrDefault();
+                    stunTarget = castingEnemies.FirstOrDefault(r => StunTracker.IsStunnable(r));
 
                     if (stunTarget == null)
                         return false;
 
                     if (await Spells.LowBlow.Cast(stunTarget))
+                    {
+                        StunTracker.RecordAttemptedStun(stunTarget);
                         return true;
+                    }
 
                     interruptTarget = castingEnemies.FirstOrDefault(r => r.SpellCastInfo.Interruptible);
 

--- a/Magitek/Logic/Samurai/Aoe.cs
+++ b/Magitek/Logic/Samurai/Aoe.cs
@@ -103,7 +103,7 @@ namespace Magitek.Logic.Samurai
             if (Core.Me.ClassLevel < 76)
                 return false;
 
-            if (Casting.LastSpell != Spells.TenkaGoken || (DateTime.Now - Casting.LastSpellTimeFinished) > TimeSpan.FromSeconds(14))
+            if (Casting.LastSpell != Spells.TenkaGoken || (DateTime.UtcNow - Casting.LastSpellTimeFinishedUtc) > TimeSpan.FromSeconds(14))
                 return false;
 
             if (SamuraiSettings.Instance.UseConeBasedAoECalculationMethod)

--- a/Magitek/Magitek.csproj
+++ b/Magitek/Magitek.csproj
@@ -414,6 +414,7 @@
     <Compile Include="Utilities\Routines\Dancer.cs" />
     <Compile Include="Utilities\Routines\Gunbreaker.cs" />
     <Compile Include="Utilities\Routines\BlueMage.cs" />
+    <Compile Include="Utilities\StunTracker.cs" />
     <Compile Include="Utilities\Weaving.cs" />
     <Compile Include="Utilities\ZoomHack.cs" />
     <Compile Include="Utilities\Duty.cs" />

--- a/Magitek/Rotations/Paladin.cs
+++ b/Magitek/Rotations/Paladin.cs
@@ -43,24 +43,25 @@ namespace Magitek.Rotations
 
             return await Combat();
         }
+
         public static async Task<bool> Heal()
         {
             if (Core.Me.IsMounted)
                 return true;
 
-
-
             if (await GambitLogic.Gambit()) return true;
             if (await Casting.TrackSpellCast()) return true;
             await Casting.CheckForSuccessfulCast();
 
-
             return await Logic.Paladin.Heal.Clemency();
         }
+
         public static async Task<bool> CombatBuff()
         {
             return false;
         }
+
+        //TODO: We should be using Reprisal in here somewhere
         public static async Task<bool> Combat()
         {
             //if (await Defensive.TankBusters()) return true;
@@ -78,6 +79,8 @@ namespace Magitek.Rotations
             if (!Core.Me.HasAura(Auras.PassageOfArms))
             {
                 if (await Buff.Oath()) return true;
+                if (await Tank.Interrupt(PaladinSettings.Instance)) return true;
+                if (await SingleTarget.ShieldBash()) return true;
 
                 if (Utilities.Routines.Paladin.OnGcd)
                 {
@@ -88,7 +91,6 @@ namespace Magitek.Rotations
                     if (await Buff.DivineVeil()) return true;
                     if (await SingleTarget.Requiescat()) return true;
                     if (await Buff.FightOrFlight()) return true;
-                    if (await SingleTarget.Interject()) return true;
                     if (!Utilities.Routines.Paladin.OGCDHold)
                     {
                         if (await SingleTarget.SpiritsWithin()) return true;
@@ -98,7 +100,6 @@ namespace Magitek.Rotations
                     if (await Buff.Sheltron()) return true;
                 }
 
-                if (await SingleTarget.ShieldBash()) return true;
                 if (await SingleTarget.ShieldLobLostAggro()) return true;
                 if (await Aoe.Confiteor()) return true;
                 if (await Aoe.HolyCircle()) return true;

--- a/Magitek/Utilities/Auras.cs
+++ b/Magitek/Utilities/Auras.cs
@@ -5,6 +5,7 @@ namespace Magitek.Utilities
     internal static class Auras
     {
         public const int
+            Stun = 2,
             Raise = 148,
             BattleVoice = 141,
             Swiftcast = 167,

--- a/Magitek/Utilities/Globals.cs
+++ b/Magitek/Utilities/Globals.cs
@@ -3,6 +3,7 @@ using ff14bot.Managers;
 using ff14bot.Objects;
 using Magitek.Enumerations;
 using Magitek.Extensions;
+using System;
 using System.Linq;
 
 namespace Magitek.Utilities
@@ -16,5 +17,8 @@ namespace Magitek.Utilities
         public static bool InActiveDuty => DutyManager.InInstance && Duty.State() == Duty.States.InProgress;
         public static GameObject HealTarget;
         public static GameVersion Language;
+
+        public static int AnimationLockMs = 700;
+        public static TimeSpan AnimationLockTimespan = TimeSpan.FromMilliseconds(AnimationLockMs);
     }
 }

--- a/Magitek/Utilities/Routines/Dancer.cs
+++ b/Magitek/Utilities/Routines/Dancer.cs
@@ -4,7 +4,7 @@ namespace Magitek.Utilities.Routines
 {
     internal static class Dancer
     {
-        public static bool OnGcd => Spells.Cascade.Cooldown > TimeSpan.FromMilliseconds(700);
+        public static bool OnGcd => Spells.Cascade.Cooldown > Globals.AnimationLockTimespan;
 
     }
 }

--- a/Magitek/Utilities/Routines/Machinist.cs
+++ b/Magitek/Utilities/Routines/Machinist.cs
@@ -9,11 +9,10 @@ namespace Magitek.Utilities.Routines
 {
     internal static class Machinist
     {
-        public static int AnimationLock = 700;
         public static bool IsInWeaveingWindow => ActionResourceManager.Machinist.OverheatRemaining != TimeSpan.Zero
                                                 ? Weaving.GetCurrentWeavingCounter() < 1 && HeatedSplitShot.Cooldown != TimeSpan.Zero
                                                 : Weaving.GetCurrentWeavingCounter() < 2 && HeatedSplitShot.Cooldown != TimeSpan.Zero
-                                                                            && HeatedSplitShot.Cooldown.TotalMilliseconds > AnimationLock + 50 + MachinistSettings.Instance.UserLatencyOffset;
+                                                                            && HeatedSplitShot.Cooldown.TotalMilliseconds > Globals.AnimationLockMs + 50 + MachinistSettings.Instance.UserLatencyOffset;
 
 
         /*

--- a/Magitek/Utilities/Routines/RedMage.cs
+++ b/Magitek/Utilities/Routines/RedMage.cs
@@ -5,6 +5,6 @@ namespace Magitek.Utilities.Routines
     internal static class RedMage
     {
         //TODO: Can we take lag into account here?
-        public static bool CanWeave => Spells.Riposte.Cooldown.TotalMilliseconds >= 700;
+        public static bool CanWeave => Spells.Riposte.Cooldown.TotalMilliseconds >= Globals.AnimationLockMs;
     }
 }

--- a/Magitek/Utilities/StunTracker.cs
+++ b/Magitek/Utilities/StunTracker.cs
@@ -1,0 +1,209 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using ff14bot.Objects;
+
+namespace Magitek.Utilities
+{
+    class StunTracker
+    {
+        //Concepts of Operation
+        //
+        //This class tracks stunned enemies to provide two services:
+        //  1: Identifying enemies that cannot be stunned
+        //  2: Identifying enemies that can be stunned, but that are on stun cooldown
+        //
+        //The first service is provided by having combat routines call ReportAttemptedStun(). This adds the reported
+        //enemy to a monitored list. If no Stun aura appears on the target within 1.5 seconds after the report, the
+        //enemy is marked as unstunnable.
+        //
+        //The second service is provided by periodically scanning all enemies. Each stunned enemy is added to a list of
+        //stunnable enemies. The fact that they've been stunned once is also recorded, along with the remaining time that
+        //they'll stay stunned.
+        //Once they're in the list of stunnable enemies, any new stuns that appear increment their stun count. Once they
+        //hit three stuns, they're reported as unstunnable for the next minute. After it expires, they go back to being
+        //stunnable again.
+        //
+        //In order benefit from these services, combat routines can call IsStunnable() before attempting to stun an enemy.
+        //
+        //Note that this code doesn't make use of permanent storage, so each time it's loaded, it will need to discover
+        //afresh what enemies can and cannot be stunned. This comes at the cost of a single stun attempt per enemy type,
+        //after which, if the enemy is unstunnable, it won't try again. Note also that this has no effect on interrupts,
+        //which will still work on interruptible spells cast by unstunnable enemies.
+
+        private const bool mEnableLogging = true;
+        private const double MaxTimeForStunToTakeEffectMs = 1500;
+
+        private static HashSet<uint> mUnstunnableEnemyIds = new HashSet<uint>();
+        private static HashSet<uint> mStunnableEnemyIds = new HashSet<uint>();
+        private static Dictionary<BattleCharacter, StunData> mAttemptedStunEnemies = new Dictionary<BattleCharacter, StunData>();
+        private static Dictionary<BattleCharacter, StunData> mStunnableEnemies = new Dictionary<BattleCharacter, StunData>();
+
+        //This must be called often to make sure we don't miss stuns
+        public static void Update(List<BattleCharacter> enemies)
+        {
+            //Update the stunnable enemies list from current enemy data
+            foreach (BattleCharacter bc in enemies)
+            {
+                Aura stun = bc.GetAuraById(Auras.Stun);
+                //This enemy is in our list because it has been stunned before. Record whether it is stunned right now.
+                if (mStunnableEnemies.ContainsKey(bc))
+                {
+                    if (bc.HasAura(Auras.Stun))
+                    {
+                        mStunnableEnemies[bc].MarkAsStunned(stun.TimespanLeft);
+                    }
+                    else
+                    {
+                        mStunnableEnemies[bc].MarkAsNotStunned();
+                    }
+                }
+                //Else the enemy hasn't been stunned before, but it is now, so add it to our list
+                else if (bc.HasAura(Auras.Stun))
+                {
+                    mStunnableEnemyIds.Add(bc.NpcId);
+                    mUnstunnableEnemyIds.Remove(bc.NpcId);
+                    mStunnableEnemies.Add(bc, new StunData(stun.TimespanLeft, bc));
+                    Log($"Added to stun list: {bc.EnglishName}");
+                }
+            }
+
+            //Maintain the stunned enemies list
+            foreach (BattleCharacter bc in mStunnableEnemies.Keys.ToList())
+            {
+                //If the enemy is dead or its stun cooldown has expired, clean it out of the list
+                if (!bc.IsAlive || mStunnableEnemies[bc].CooldownExpired)
+                {
+                    Log($"Removed from stun list: {bc.EnglishName}");
+                    if (bc.IsAlive)
+                    {
+                        Log($"{bc.EnglishName.ToUpper()} COOLDOWN RESET");
+                    }
+                    mStunnableEnemies.Remove(bc);
+                }
+            }
+
+            //Maintain the attempted stuns list
+            foreach (BattleCharacter bc in mAttemptedStunEnemies.Keys.ToList())
+            {
+                //If the enemy is dead or it has been moved to the stunnable list, clean it out of the attempted stun list
+                if (!bc.IsAlive || mStunnableEnemies.ContainsKey(bc))
+                {
+                    Log($"Removed from attempted stun list: {bc.EnglishName}");
+                    mAttemptedStunEnemies.Remove(bc);
+                }
+                //Else if it's been long enough since the stun attempt was reported, and no stun aura has appeared, the enemy isn't stunnable
+                else if (mAttemptedStunEnemies[bc].MsSinceLastStun > MaxTimeForStunToTakeEffectMs)
+                {
+                    Log($"Removed from attempted stun list: {bc.EnglishName}");
+                    mAttemptedStunEnemies.Remove(bc);
+                    //Just in case we had a false positive, make sure it isn't already known to be stunnable
+                    if (!mStunnableEnemyIds.Contains(bc.NpcId))
+                    {
+                        Log($"Added to unstunnable list: {bc.EnglishName}");
+                        mUnstunnableEnemyIds.Add(bc.NpcId);
+                    }
+                }
+            }
+        }
+
+        //Method intended for combat routines to report an attempted stun. This allows the StunTracker to determine
+        //if an enemy is stunnable or not
+        public static void RecordAttemptedStun(BattleCharacter enemy)
+        {
+            //If we've already seen it before, we know whether it can be stunned, so don't bother doing it again
+            if (   !mUnstunnableEnemyIds.Contains(enemy.NpcId)
+                && !mStunnableEnemyIds.Contains(enemy.NpcId)
+                && !mStunnableEnemies.ContainsKey(enemy)
+                && !mAttemptedStunEnemies.ContainsKey(enemy))
+            {
+                Log($"Recording attempted stun: {enemy.EnglishName}");
+                mAttemptedStunEnemies.Remove(enemy);
+                mAttemptedStunEnemies.Add(enemy, new StunData(TimeSpan.Zero, enemy));
+            }
+        }
+
+        //Method intended for use by combat routines to check if an enemy is stunnable before trying to stun it
+        //This will report "true" for unknown enemies. If they resist the stun, it will report "false" afterward.
+        public static bool IsStunnable(BattleCharacter enemy)
+        {
+            // - If they're in the unstunnable list, return false
+            // - If they're in the stun list and they're on cooldown, return false
+            // - If they're in the attempted stun list, we already tried stunning within the last
+            //   1500 ms. Either the stun hasn't had time to show up yet, in which case we don't
+            //   need to try to stun again already, or they're immune. Either way, return false
+            // - If they're already stunned, return false
+            //TODO: Figure out a way to prevent trying to stun immediately after an interrupt
+            if (   !mUnstunnableEnemyIds.Contains(enemy.NpcId)
+                && (!mStunnableEnemies.ContainsKey(enemy) || !mStunnableEnemies[enemy].OnCooldown)
+                && !mAttemptedStunEnemies.ContainsKey(enemy)
+                && !enemy.HasAura(Auras.Stun))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private static void Log(string strToLog)
+        {
+            if (mEnableLogging)
+            {
+                Logger.WriteInfo($"[StunTracker] {strToLog}");
+            }
+        }
+
+        private class StunData
+        {
+            private const double CooldownTimeoutMs = 60000;
+
+            private int StunCount;
+            private DateTime TimeStunDetected;
+            private TimeSpan TimeLeftOnStun;
+            private BattleCharacter Enemy;
+
+            public double MsSinceLastStun => DateTime.UtcNow.Subtract(TimeStunDetected).TotalMilliseconds;
+            public bool OnCooldown => StunCount > 2;
+            public bool CooldownExpired => MsSinceLastStun > CooldownTimeoutMs;
+
+            public StunData(TimeSpan timeLeftOnStun, BattleCharacter enemy)
+            {
+                Enemy = enemy;
+                TimeStunDetected = DateTime.UtcNow;
+                TimeLeftOnStun = timeLeftOnStun;
+                if (timeLeftOnStun > TimeSpan.Zero)
+                {
+                    Log($"Stun count = 1 on {Enemy.EnglishName}");
+                    StunCount = 1;
+                }
+                else
+                {
+                    Log($"Stun count = 0 on {Enemy.EnglishName}");
+                    StunCount = 0;
+                }
+            }
+
+            public void MarkAsStunned(TimeSpan timeLeftOnStun)
+            {
+                //They're stunned, and thre's more time left on their stun than the last time this was called.
+                //This means they've been stunned again.
+                if (timeLeftOnStun > TimeLeftOnStun)
+                {
+                    StunCount++;
+                    TimeStunDetected = DateTime.UtcNow;
+                    Log($"Stun count = {StunCount} on {Enemy.EnglishName}");
+                    if (OnCooldown)
+                    {
+                        Log($"{Enemy.EnglishName.ToUpper()} ON COOLDOWN");
+                    }
+                }
+                TimeLeftOnStun = timeLeftOnStun;
+            }
+
+            public void MarkAsNotStunned()
+            {
+                TimeLeftOnStun = TimeSpan.Zero;
+            }
+        }
+    }
+}

--- a/Magitek/Utilities/Tracking.cs
+++ b/Magitek/Utilities/Tracking.cs
@@ -163,6 +163,8 @@ namespace Magitek.Utilities
             }
 
             Debug.Instance.Enemies = new ObservableCollection<EnemyInfo>(EnemyInfos);
+
+            StunTracker.Update(Combat.Enemies);
         }
 
         private static void UpdateCurrentPosition()

--- a/Magitek/Views/UserControls/Paladin/Combat.xaml
+++ b/Magitek/Views/UserControls/Paladin/Combat.xaml
@@ -4,10 +4,22 @@
              xmlns:controls="clr-namespace:Magitek.Controls"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:enums="clr-namespace:Magitek.Enumerations"
+             xmlns:sys="clr-namespace:System;assembly=mscorlib"
              xmlns:viewModels="clr-namespace:Magitek.ViewModels"
              d:DesignHeight="420"
              d:DesignWidth="500"
              mc:Ignorable="d">
+
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ObjectDataProvider x:Key="InterruptStrategy" MethodName="GetValues" ObjectType="{x:Type sys:Enum}">
+                <ObjectDataProvider.MethodParameters>
+                    <x:Type TypeName="enums:InterruptStrategy" />
+                </ObjectDataProvider.MethodParameters>
+            </ObjectDataProvider>
+        </ResourceDictionary>
+    </UserControl.Resources>
 
     <UserControl.DataContext>
         <Binding Source="{x:Static viewModels:BaseSettings.Instance}" />
@@ -52,13 +64,6 @@
             </StackPanel>
         </controls:SettingsBlock>
 
-
-        <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
-            <StackPanel Margin="5">
-                <CheckBox Content="Interrupt With Interject" IsChecked="{Binding PaladinSettings.UseInterject, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                <CheckBox Margin="0,3,0,0" Content="Use Shield Bash To Stun On Spell Casts" IsChecked="{Binding PaladinSettings.ShieldBash, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-            </StackPanel>
-        </controls:SettingsBlock>
 
         <controls:SettingsBlock Background="{DynamicResource ClassSelectorBackground}">
             <StackPanel Margin="5">
@@ -111,6 +116,17 @@
             </StackPanel>
         </controls:SettingsBlock>
 
+        <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
+            <StackPanel Margin="5">
+                <CheckBox Margin="0,3,0,0" Content="Use Stun" IsChecked="{Binding PaladinSettings.UseInterrupt, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                <CheckBox Margin="24,3,0,0" Content="Stun with Shield Bash" IsChecked="{Binding PaladinSettings.ShieldBash, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                <CheckBox Content="Use Interrupt" IsChecked="{Binding PaladinSettings.UseInterject, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Margin="0,0,10,0" Style="{DynamicResource TextBlockDefault}" Text="Selected Interrupt Strategy:" />
+                    <ComboBox Width="170" ItemsSource="{Binding Source={StaticResource InterruptStrategy}}" SelectedValue="{Binding PaladinSettings.Strategy, Mode=TwoWay}" Style="{DynamicResource ComboBox}" />
+                </StackPanel>
+            </StackPanel>
+        </controls:SettingsBlock>
 
     </StackPanel>
 </UserControl>


### PR DESCRIPTION
- Added utility class to track stuns on enemies
    - Will identify unstunnable enemies
    - Will identify enemies on stun cooldown
- Update standard Tank.Interrupt routine to use new stun tracker utility
- Update Tank.Interrupt routine to try to stun non-interruptible spells
- Update Tank.Interrupt routine to sort interruptible/stunnable spells by the amount of time left and try to interrupt/stun the one going off soonest
- Update Tank.Interrupt routine to filter out interruptible/stunnable spells that will go off before we can get them
- Update PLD to use standard Tank.Interrupt routine, plus Shield Bash
- Added UI for PLD to configure interrupt/stun behavior
- Refactor animation lock time into global
- Replace DateTime.Now with DateTime.UtcNow for performance reasons
- SpellCastHistory items can now tell you how much time is left on their animation lock