### PR TITLE
Remove docile enemies from enemy list

### DIFF
--- a/Magitek/Utilities/Tracking.cs
+++ b/Magitek/Utilities/Tracking.cs
@@ -34,8 +34,12 @@ namespace Magitek.Utilities
                 else
                 {
                     //In an instance, not autonomous
-                    //Track every enemy
-                    _enemyCache = GameObjectManager.GetObjectsOfType<BattleCharacter>().ToList();
+                    //Track every tagged or aggroed enemy in the vicinity
+                    _enemyCache = GameObjectManager.GetObjectsOfType<BattleCharacter>().Where(r =>    (   r.TaggerType > 0
+                                                                                                       || r.HasTarget
+                                                                                                       || r.IsBoss())
+                                                                                                   && Core.Me.Distance(r) < 50)
+                                                                                       .ToList();
                 }
             }
             else


### PR DESCRIPTION
The recent change to track all enemies in dungeons had some unintended consequences. Specifically, a lot of code assumes that all enemies in the Enemies list are currently in combat. This fix respects that assumption while still allowing AoE before everything is tagged.