### PR TITLE
WHM: Make sure group members are only counted once

### DIFF
--- a/Magitek/Utilities/Routines/WhiteMage.cs
+++ b/Magitek/Utilities/Routines/WhiteMage.cs
@@ -137,9 +137,13 @@ namespace Magitek.Utilities.Routines
                 // Create a list of alliance members that we need to check
                 if (WhiteMageSettings.Instance.HealAllianceDps || WhiteMageSettings.Instance.HealAllianceHealers || WhiteMageSettings.Instance.HealAllianceTanks)
                 {
-                    var allianceToHeal = Group.AllianceMembers.Where(a => !a.CanAttack && !a.HasAura(Auras.MountedPvp) && (WhiteMageSettings.Instance.HealAllianceDps && a.IsDps() ||
-                                                                          WhiteMageSettings.Instance.HealAllianceTanks && a.IsTank() ||
-                                                                          WhiteMageSettings.Instance.HealAllianceHealers && a.IsDps()));
+                    //Exclude the party members - they've already been handled by Group.UpdateAllies, and we don't want them in the list twice
+                    var allianceToHeal = Group.AllianceMembers.Except(PartyManager.AllMembers.Select(r => r.BattleCharacter))
+                                                              .Where(a =>    !a.CanAttack
+                                                                          && !a.HasAura(Auras.MountedPvp)
+                                                                          && (   WhiteMageSettings.Instance.HealAllianceDps && a.IsDps()
+                                                                              || WhiteMageSettings.Instance.HealAllianceTanks && a.IsTank()
+                                                                              || WhiteMageSettings.Instance.HealAllianceHealers && a.IsDps()));
 
                     // If all we're going to do with the alliance is Physick them, then simply use this list
                     if (WhiteMageSettings.Instance.HealAllianceOnlyCure)


### PR DESCRIPTION
The Group.UpdateAllies method handles tracking your allies. You can also pass in an extension method, which it will call when it's done with its main processing. The WHM extension method adds alliance members to the list of allies, if that option is checked. However, it *also* adds all of the group members again. Having duplicate group members was messing up the logic for, e.g., Cure III, where it thought that each injured group member was actually two injured group members.
This change also optimizes the Cure III target to ensure it heals the most possible damaged people.