### PR TITLE
Prevent StunTracker from accessing invalid objects

### DIFF
--- a/Magitek/Utilities/StunTracker.cs
+++ b/Magitek/Utilities/StunTracker.cs
@@ -80,6 +80,13 @@ namespace Magitek.Utilities
             //Maintain the stunned enemies list
             foreach (BattleCharacter bc in mStunnableEnemies.Keys.ToList())
             {
+                if (!bc.IsValid)
+                {
+                    Log(LogLevel.Debug, $"Removed no-longer-valid enemy from stun list");
+                    mStunnableEnemies.Remove(bc);
+                    continue;
+                }
+
                 //If the enemy is dead or its stun cooldown has expired, clean it out of the list
                 if (!bc.IsAlive || mStunnableEnemies[bc].CooldownExpired)
                 {
@@ -95,8 +102,15 @@ namespace Magitek.Utilities
             //Maintain the attempted stuns list
             foreach (BattleCharacter bc in mAttemptedStunEnemies.Keys.ToList())
             {
+                if (!bc.IsValid)
+                {
+                    Log(LogLevel.Debug, $"Removed no-longer-valid enemy from attempted stun list");
+                    mStunnableEnemies.Remove(bc);
+                    continue;
+                }
+
                 //If the enemy is dead or it has been moved to the stunnable list, clean it out of the attempted stun list
-                if (!bc.IsAlive || mStunnableEnemies.ContainsKey(bc))
+                if (!bc.IsValid || !bc.IsAlive || mStunnableEnemies.ContainsKey(bc))
                 {
                     Log(LogLevel.Debug, $"Removed from attempted stun list: {bc.EnglishName}");
                     mAttemptedStunEnemies.Remove(bc);

--- a/Magitek/Utilities/StunTracker.cs
+++ b/Magitek/Utilities/StunTracker.cs
@@ -105,7 +105,7 @@ namespace Magitek.Utilities
                 if (!bc.IsValid)
                 {
                     Log(LogLevel.Debug, $"Removed no-longer-valid enemy from attempted stun list");
-                    mStunnableEnemies.Remove(bc);
+                    mAttemptedStunEnemies.Remove(bc);
                     continue;
                 }
 

--- a/Magitek/Utilities/StunTracker.cs
+++ b/Magitek/Utilities/StunTracker.cs
@@ -110,7 +110,7 @@ namespace Magitek.Utilities
                 }
 
                 //If the enemy is dead or it has been moved to the stunnable list, clean it out of the attempted stun list
-                if (!bc.IsValid || !bc.IsAlive || mStunnableEnemies.ContainsKey(bc))
+                if (!bc.IsAlive || mStunnableEnemies.ContainsKey(bc))
                 {
                     Log(LogLevel.Debug, $"Removed from attempted stun list: {bc.EnglishName}");
                     mAttemptedStunEnemies.Remove(bc);


### PR DESCRIPTION
The StunTracker code caches BattleCharacter objects to remember which have been stunned, and how many times. It's apparently not safe to access them without checking IsValid first, in case they've been cleaned up since last we looked at them.