### PR TITLE
General: Centralize stun & interrupt logic

### DIFF
--- a/Magitek/Enumerations/InterruptStrategy.cs
+++ b/Magitek/Enumerations/InterruptStrategy.cs
@@ -2,8 +2,9 @@
 {
     public enum InterruptStrategy
     {
-        NeverInterrupt,
-        InterruptOnlyBosses,
-        AlwaysInterrupt,
+        Never,
+        BossesOnly,
+        Always,
+        CurrentTargetOnly,
     }
 }

--- a/Magitek/Enumerations/InterruptStrategy.cs
+++ b/Magitek/Enumerations/InterruptStrategy.cs
@@ -4,7 +4,7 @@
     {
         Never,
         BossesOnly,
-        Always,
+        AnyEnemy,
         CurrentTargetOnly,
     }
 }

--- a/Magitek/Logic/Bard/Utility.cs
+++ b/Magitek/Logic/Bard/Utility.cs
@@ -28,25 +28,6 @@ namespace Magitek.Logic.Bard
 
         }
 
-        public static async Task<bool> HeadGraze()
-        {
-
-            if (!BardSettings.Instance.UseHeadGraze)
-                return false;
-
-            BattleCharacter interruptTarget = null;
-
-            interruptTarget = BardSettings.Instance.OnlyInterruptCurrentTarget ?
-                Combat.Enemies.FirstOrDefault(r => r.InView() && r == Core.Me.CurrentTarget && r.IsCasting && r.SpellCastInfo.Interruptible)
-                : Combat.Enemies.FirstOrDefault(r => r.InView() && r.IsCasting && r.SpellCastInfo.Interruptible);
-
-            if (interruptTarget == null)
-                return false;
-
-            return await Spells.HeadGraze.Cast(interruptTarget);
-
-        }
-
         public static async Task<bool> RepellingShot()
         {
             if (!BardSettings.Instance.RepellingShot)

--- a/Magitek/Logic/InterruptLogic.cs
+++ b/Magitek/Logic/InterruptLogic.cs
@@ -1,0 +1,80 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using ff14bot;
+using ff14bot.Objects;
+using Magitek.Enumerations;
+using Magitek.Extensions;
+using Magitek.Models.Account;
+using Magitek.Utilities;
+
+namespace Magitek.Logic
+{
+    internal static class InterruptAndStunLogic
+    {
+        public static async Task<bool> DoStunAndInterrupt(IEnumerable<SpellData> stuns, IEnumerable<SpellData> interrupts, InterruptStrategy strategy)
+        {
+            IEnumerable<BattleCharacter> castingEnemies;
+
+            if (strategy == InterruptStrategy.Never)
+            {
+                castingEnemies = new List<BattleCharacter>();
+            }
+            else
+            {
+                castingEnemies = Combat.Enemies;
+                if (strategy == InterruptStrategy.BossesOnly)
+                {
+                    castingEnemies = castingEnemies.Where(e => e.IsBoss());
+                }
+                else if (strategy == InterruptStrategy.CurrentTargetOnly)
+                {
+                    castingEnemies = castingEnemies.Where(e => e == Core.Me.CurrentTarget);
+                }
+
+                //The amount of time before our interrupt will go off
+                int minimumMsLeftOnEnemyCast =   BaseSettings.Instance.UserLatencyOffset
+                                               + Globals.AnimationLockMs
+                                               + Casting.SpellCastHistory.LastOrDefault()?.AnimationLockRemainingMs ?? 0;
+
+                castingEnemies = castingEnemies.Where(r =>    r.InView()
+                                                           && r.IsCasting
+                                                           && r.SpellCastInfo.RemainingCastTime.TotalMilliseconds >= minimumMsLeftOnEnemyCast)
+                                               .OrderBy(r => r.SpellCastInfo.RemainingCastTime);
+            }
+
+            foreach (SpellData stun in stuns)
+            {
+                BattleCharacter stunTarget = castingEnemies.FirstOrDefault(enemy => StunTracker.IsStunnable(enemy) && enemy.Distance(Core.Me) <= stun.Range + Core.Me.CombatReach + enemy.CombatReach);
+
+                if (stunTarget == null)
+                {
+                    continue;
+                }
+
+                if (await stun.Cast(stunTarget))
+                {
+                    StunTracker.RecordAttemptedStun(stunTarget);
+                    return true;
+                }
+            }
+
+            foreach (SpellData interrupt in interrupts)
+            {
+                BattleCharacter interruptTarget = castingEnemies.FirstOrDefault(enemy => enemy.SpellCastInfo.Interruptible && enemy.Distance(Core.Me) <= interrupt.Range + Core.Me.CombatReach + enemy.CombatReach);
+
+                if (interruptTarget == null)
+                {
+                    continue;
+                }
+
+                if (await interrupt.Cast(interruptTarget))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/Magitek/Logic/Machinist/Utility.cs
+++ b/Magitek/Logic/Machinist/Utility.cs
@@ -24,23 +24,5 @@ namespace Magitek.Logic.Machinist
 
         }
 
-        public static async Task<bool> HeadGraze()
-        {
-
-            if (!MachinistSettings.Instance.UseHeadGraze)
-                return false;
-
-            BattleCharacter interruptTarget = null;
-
-            interruptTarget = MachinistSettings.Instance.OnlyInterruptCurrentTarget ?
-                Combat.Enemies.FirstOrDefault(r => r.InView() && r == Core.Me.CurrentTarget && r.IsCasting && r.SpellCastInfo.Interruptible)
-                : Combat.Enemies.FirstOrDefault(r => r.InView() && r.IsCasting && r.SpellCastInfo.Interruptible);
-
-            if (interruptTarget == null)
-                return false;
-
-            return await Spells.HeadGraze.Cast(interruptTarget);
-
-        }
     }
 }

--- a/Magitek/Logic/Paladin/Buff.cs
+++ b/Magitek/Logic/Paladin/Buff.cs
@@ -23,12 +23,12 @@ namespace Magitek.Logic.Paladin
                     PaladinSettings.Instance.UseDefensives = PaladinSettings.Instance.SwordDefensive;
                     PaladinSettings.Instance.UseClemency = PaladinSettings.Instance.SwordClemency;
                     PaladinSettings.Instance.UseProvoke = PaladinSettings.Instance.SwordProvoke;
-                    PaladinSettings.Instance.UseInterject = PaladinSettings.Instance.SwordInterrupt;
                     PaladinSettings.Instance.ShieldBash = PaladinSettings.Instance.SwordShieldBash;
                     PaladinSettings.Instance.UseCover = PaladinSettings.Instance.SwordCover;
                     PaladinSettings.Instance.ShieldLobToPullExtraEnemies = PaladinSettings.Instance.SwordPullExtra;
                     PaladinSettings.Instance.ShieldLobLostAggro = PaladinSettings.Instance.SwordPullExtra;
                     PaladinSettings.Instance.Requiescat = PaladinSettings.Instance.SwordRequiecast;
+                    PaladinSettings.Instance.Strategy = PaladinSettings.Instance.SwordStrategy;
                 }
 
                 return await Spells.IronWill.Cast(Core.Me);
@@ -42,12 +42,12 @@ namespace Magitek.Logic.Paladin
                     PaladinSettings.Instance.UseDefensives = PaladinSettings.Instance.ShieldDefensive;
                     PaladinSettings.Instance.UseClemency = PaladinSettings.Instance.ShieldClemency;
                     PaladinSettings.Instance.UseProvoke = PaladinSettings.Instance.ShieldProvoke;
-                    PaladinSettings.Instance.UseInterject = PaladinSettings.Instance.ShieldInterrupt;
                     PaladinSettings.Instance.ShieldBash = PaladinSettings.Instance.ShieldShieldBash;
                     PaladinSettings.Instance.UseCover = PaladinSettings.Instance.ShieldCover;
                     PaladinSettings.Instance.ShieldLobToPullExtraEnemies = PaladinSettings.Instance.ShieldPullExtra;
                     PaladinSettings.Instance.ShieldLobLostAggro = PaladinSettings.Instance.ShieldPullExtra;
                     PaladinSettings.Instance.Requiescat = PaladinSettings.Instance.ShieldRequiecast;
+                    PaladinSettings.Instance.Strategy = PaladinSettings.Instance.ShieldStrategy;
                 }
 
                 return await Spells.IronWill.Cast(Core.Me);

--- a/Magitek/Logic/Paladin/SingleTarget.cs
+++ b/Magitek/Logic/Paladin/SingleTarget.cs
@@ -1,9 +1,8 @@
 using ff14bot;
 using ff14bot.Managers;
 using ff14bot.Objects;
-using Magitek.Enumerations;
 using Magitek.Extensions;
-using Magitek.Models.Account;
+using Magitek.Logic.Roles;
 using Magitek.Models.Paladin;
 using Magitek.Utilities;
 using System.Collections.Generic;
@@ -87,70 +86,6 @@ namespace Magitek.Logic.Paladin
             }
 
             return await Spells.SpiritsWithin.Cast(Core.Me.CurrentTarget);
-        }
-
-        //TODO: This uses nearly the same logic as Tank.Interrupt(). Refactor to make it all one.
-        //      Or, for extra credit, make an interrupt routine that can be used by any class - perhaps they pass in stuns, interrupts, and priorities, or something?
-        public static async Task<bool> ShieldBash()
-        {
-            if (!PaladinSettings.Instance.UseInterrupt || !PaladinSettings.Instance.ShieldBash)
-                return false;
-
-            //The amount of time before our interrupt will go off
-            int minimumMsLeftOnEnemyCast =   BaseSettings.Instance.UserLatencyOffset
-                                           + Globals.AnimationLockMs
-                                           + Casting.SpellCastHistory.LastOrDefault()?.AnimationLockRemainingMs ?? 0;
-
-            BattleCharacter stunTarget;
-
-            switch (PaladinSettings.Instance.Strategy)
-            {
-                case InterruptStrategy.NeverInterrupt:
-                    return false;
-
-                case InterruptStrategy.InterruptOnlyBosses:
-                    stunTarget = GameObjectManager.Attackers.Where(r =>    r.IsBoss()
-                                                                        && r.InView()
-                                                                        && r.IsCasting
-                                                                        && StunTracker.IsStunnable(r)
-                                                                        && r.SpellCastInfo.RemainingCastTime.TotalMilliseconds >= minimumMsLeftOnEnemyCast)
-                                                            .OrderBy(r => r.SpellCastInfo.RemainingCastTime)
-                                                            .FirstOrDefault();
-
-                    if (stunTarget == null)
-                        return false;
-
-                    if (await Spells.ShieldBash.Cast(stunTarget))
-                    {
-                        StunTracker.RecordAttemptedStun(stunTarget);
-                        return true;
-                    }
-
-                    return false;
-
-                case InterruptStrategy.AlwaysInterrupt:
-                    stunTarget =
-                        Combat.Enemies.Where(r =>    r.InView()
-                                                  && r.IsCasting
-                                                  && StunTracker.IsStunnable(r)
-                                                  && r.SpellCastInfo.RemainingCastTime.TotalMilliseconds > minimumMsLeftOnEnemyCast)
-                                      .OrderBy(r => r.SpellCastInfo.RemainingCastTime)
-                                      .FirstOrDefault();
-
-                    if (stunTarget == null)
-                        return false;
-
-                    if (await Spells.ShieldBash.Cast(stunTarget))
-                    {
-                        StunTracker.RecordAttemptedStun(stunTarget);
-                        return true;
-                    }
-
-                    return false;
-
-                default:
-                    return false;
-            }
         }
 
         public static async Task<bool> Requiescat()
@@ -239,6 +174,18 @@ namespace Magitek.Logic.Paladin
                 return false;
 
             return await Spells.Atonement.Cast(Core.Me.CurrentTarget);
+        }
+
+        public static async Task<bool> Interrupt()
+        {
+            List<SpellData> extraStun = new List<SpellData>();
+
+            if (PaladinSettings.Instance.ShieldBash)
+            {
+                extraStun.Add(Spells.ShieldBash);
+            }
+
+            return await Tank.Interrupt(PaladinSettings.Instance, extraStuns: extraStun);
         }
     }
 }

--- a/Magitek/Logic/RedMage/Aoe.cs
+++ b/Magitek/Logic/RedMage/Aoe.cs
@@ -160,9 +160,11 @@ namespace Magitek.Logic.RedMage
                 return await Spells.Manafication.Cast(Core.Me);
         }
 
+        public const double MoulinetRange = 8.0;
+
         private static bool InMoulinetRange(GameObject target)
         {
-            return target != null && target.InView() && target.Distance(Core.Me) <= target.CombatReach + Core.Me.CombatReach + Spells.Moulinet.Radius;
+            return target != null && target.InView() && target.Distance(Core.Me) <= target.CombatReach + Core.Me.CombatReach + MoulinetRange;
         }
 
         public static async Task<bool> Moulinet()

--- a/Magitek/Logic/Roles/PhysicalDPS.cs
+++ b/Magitek/Logic/Roles/PhysicalDPS.cs
@@ -84,7 +84,7 @@ namespace Magitek.Logic.Roles
                 interrupts.Add(Spells.HeadGraze);
             }
 
-            return await InterruptAndStunLogic.DoStunAndInterrupt(stuns, interrupts, settings.Strategy);
+            return await InterruptAndStunLogic.StunOrInterrupt(stuns, interrupts, settings.Strategy);
         }
 
         public static async Task<bool> Peloton<T>(T settings) where T : PhysicalDpsSettings

--- a/Magitek/Logic/Roles/Tank.cs
+++ b/Magitek/Logic/Roles/Tank.cs
@@ -81,7 +81,7 @@ namespace Magitek.Logic.Roles
                 interrupts.AddRange(extraInterrupts);
             }
 
-            return await InterruptAndStunLogic.DoStunAndInterrupt(stuns, interrupts, settings.Strategy);
+            return await InterruptAndStunLogic.StunOrInterrupt(stuns, interrupts, settings.Strategy);
         }
     }
 }

--- a/Magitek/Magitek.csproj
+++ b/Magitek/Magitek.csproj
@@ -241,6 +241,7 @@
     <Compile Include="Logic\Dragoon\Jumps.cs" />
     <Compile Include="Logic\Dragoon\SingleTarget.cs" />
     <Compile Include="Logic\GambitLogic.cs" />
+    <Compile Include="Logic\InterruptLogic.cs" />
     <Compile Include="Logic\Machinist\Utility.cs" />
     <Compile Include="Logic\Machinist\MultiTarget.cs" />
     <Compile Include="Logic\Machinist\Cooldowns.cs" />

--- a/Magitek/Models/Bard/BardSettings.cs
+++ b/Magitek/Models/Bard/BardSettings.cs
@@ -261,14 +261,6 @@ namespace Magitek.Models.Bard
 
         [Setting]
         [DefaultValue(false)]
-        public bool UseHeadGraze { get; set; }
-
-        [Setting]
-        [DefaultValue(true)]
-        public bool OnlyInterruptCurrentTarget { get; set; }
-
-        [Setting]
-        [DefaultValue(false)]
         public bool RepellingShot { get; set; }
 
         [Setting]

--- a/Magitek/Models/Dragoon/DragoonSettings.cs
+++ b/Magitek/Models/Dragoon/DragoonSettings.cs
@@ -70,10 +70,6 @@ namespace Magitek.Models.Dragoon
         public bool DragonfireDive { get; set; }
 
         [Setting]
-        [DefaultValue(true)]
-        public bool Stun { get; set; }
-
-        [Setting]
         [DefaultValue(70.0f)]
         public float RestHealthPercent { get; set; }
 

--- a/Magitek/Models/Machinist/MachinistSettings.cs
+++ b/Magitek/Models/Machinist/MachinistSettings.cs
@@ -134,14 +134,6 @@ namespace Magitek.Models.Machinist
         [DefaultValue(true)]
         public bool ForceTactician { get; internal set; }
 
-        [Setting]
-        [DefaultValue(false)]
-        public bool UseHeadGraze { get; set; }
-
-        [Setting]
-        [DefaultValue(true)]
-        public bool OnlyInterruptCurrentTarget { get; set; }
-
         #endregion
 
 

--- a/Magitek/Models/Paladin/PaladinSettings.cs
+++ b/Magitek/Models/Paladin/PaladinSettings.cs
@@ -242,10 +242,6 @@ namespace Magitek.Models.Paladin
 
         [Setting]
         [DefaultValue(false)]
-        public bool SwordInterrupt { get; set; }
-
-        [Setting]
-        [DefaultValue(false)]
         public bool SwordShieldBash { get; set; }
 
         [Setting]
@@ -265,6 +261,10 @@ namespace Magitek.Models.Paladin
         public bool SwordRequiecast { get; set; }
 
         [Setting]
+        [DefaultValue(InterruptStrategy.Never)]
+        public InterruptStrategy SwordStrategy { get; set; }
+
+        [Setting]
         [DefaultValue(false)]
         public bool ShieldDefensive { get; set; }
 
@@ -275,10 +275,6 @@ namespace Magitek.Models.Paladin
         [Setting]
         [DefaultValue(false)]
         public bool ShieldProvoke { get; set; }
-
-        [Setting]
-        [DefaultValue(false)]
-        public bool ShieldInterrupt { get; set; }
 
         [Setting]
         [DefaultValue(false)]
@@ -299,6 +295,10 @@ namespace Magitek.Models.Paladin
         [Setting]
         [DefaultValue(false)]
         public bool ShieldRequiecast { get; set; }
+
+        [Setting]
+        [DefaultValue(InterruptStrategy.Never)]
+        public InterruptStrategy ShieldStrategy { get; set; }
 
         #endregion
 

--- a/Magitek/Models/Roles/PhysicalDpsSettings.cs
+++ b/Magitek/Models/Roles/PhysicalDpsSettings.cs
@@ -24,7 +24,7 @@ namespace Magitek.Models.Roles
         public float SecondWindHealthPercent { get; set; }
 
         [Setting]
-        [DefaultValue(InterruptStrategy.AlwaysInterrupt)]
+        [DefaultValue(InterruptStrategy.Always)]
         public InterruptStrategy Strategy { get; set; }
 
         [Setting]

--- a/Magitek/Models/Roles/PhysicalDpsSettings.cs
+++ b/Magitek/Models/Roles/PhysicalDpsSettings.cs
@@ -24,7 +24,7 @@ namespace Magitek.Models.Roles
         public float SecondWindHealthPercent { get; set; }
 
         [Setting]
-        [DefaultValue(InterruptStrategy.Always)]
+        [DefaultValue(InterruptStrategy.AnyEnemy)]
         public InterruptStrategy Strategy { get; set; }
 
         [Setting]

--- a/Magitek/Models/Roles/TankSettings.cs
+++ b/Magitek/Models/Roles/TankSettings.cs
@@ -58,7 +58,7 @@ namespace Magitek.Models.Roles
         public int ReprisalHealthPercent { get; set; }
 
         [Setting]
-        [DefaultValue(InterruptStrategy.Always)]
+        [DefaultValue(InterruptStrategy.AnyEnemy)]
         public InterruptStrategy Strategy { get; set; }
     }
 }

--- a/Magitek/Models/Roles/TankSettings.cs
+++ b/Magitek/Models/Roles/TankSettings.cs
@@ -43,14 +43,6 @@ namespace Magitek.Models.Roles
 
         [Setting]
         [DefaultValue(true)]
-        public bool UseInterject { get; set; }
-
-        [Setting]
-        [DefaultValue(true)]
-        public bool UseInterrupt { get; set; }
-
-        [Setting]
-        [DefaultValue(true)]
         public bool UseRampart { get; set; }
 
         [Setting]
@@ -66,7 +58,7 @@ namespace Magitek.Models.Roles
         public int ReprisalHealthPercent { get; set; }
 
         [Setting]
-        [DefaultValue(InterruptStrategy.AlwaysInterrupt)]
+        [DefaultValue(InterruptStrategy.Always)]
         public InterruptStrategy Strategy { get; set; }
     }
 }

--- a/Magitek/Models/Samurai/SamuraiSettings.cs
+++ b/Magitek/Models/Samurai/SamuraiSettings.cs
@@ -1,13 +1,13 @@
-using ff14bot.Helpers;
 using Magitek.Enumerations;
 using PropertyChanged;
 using System.ComponentModel;
 using System.Configuration;
+using Magitek.Models.Roles;
 
 namespace Magitek.Models.Samurai
 {
     [AddINotifyPropertyChangedInterface]
-    public class SamuraiSettings : JsonSettings, IRoutineSettings
+    public class SamuraiSettings : PhysicalDpsSettings, IRoutineSettings
     {
         public SamuraiSettings() : base(CharacterSettingsDirectory + "/Magitek/Samurai/SamuraiSettings.json") { }
 

--- a/Magitek/Rotations/Bard.cs
+++ b/Magitek/Rotations/Bard.cs
@@ -111,7 +111,7 @@ namespace Magitek.Rotations
                 if (await Utility.Troubadour()) return true;
                 if (await PhysicalDps.ArmsLength(BardSettings.Instance)) return true;
                 if (await PhysicalDps.SecondWind(BardSettings.Instance)) return true;
-                if (await Utility.HeadGraze()) return true;
+                if (await PhysicalDps.Interrupt(BardSettings.Instance)) return true;
 
                 // Damage
                 if (await SingleTarget.LastPossiblePitchPerfectDuringWM()) return true;

--- a/Magitek/Rotations/Dancer.cs
+++ b/Magitek/Rotations/Dancer.cs
@@ -108,6 +108,7 @@ namespace Magitek.Rotations
             if (Utilities.Routines.Dancer.OnGcd)
             {
                 //Only cast spells that are instant/off gcd
+                if (await PhysicalDps.Interrupt(DancerSettings.Instance)) return true;
                 if (await Buff.PreTechnicalDevilment()) return true;
                 if (await Aoe.FanDance3()) return true;
                 if (await Aoe.FanDance2()) return true;

--- a/Magitek/Rotations/Dragoon.cs
+++ b/Magitek/Rotations/Dragoon.cs
@@ -162,6 +162,7 @@ namespace Magitek.Rotations
             }
             #endregion
 
+            if (await PhysicalDps.Interrupt(DragoonSettings.Instance)) return true;
             if (await PhysicalDps.SecondWind(DragoonSettings.Instance)) return true;
             if (await PhysicalDps.Bloodbath(DragoonSettings.Instance)) return true;
 

--- a/Magitek/Rotations/Gunbreaker.cs
+++ b/Magitek/Rotations/Gunbreaker.cs
@@ -3,6 +3,7 @@ using ff14bot.Managers;
 using Magitek.Extensions;
 using Magitek.Logic;
 using Magitek.Logic.Gunbreaker;
+using Magitek.Logic.Roles;
 using Magitek.Models.Gunbreaker;
 using Magitek.Utilities;
 using System.Threading.Tasks;
@@ -55,6 +56,7 @@ namespace Magitek.Rotations
         {
             return false;
         }
+
         public static async Task<bool> Combat()
         {
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
@@ -72,8 +74,8 @@ namespace Magitek.Rotations
                 Movement.NavigateToUnitLos(Core.Me.CurrentTarget, 3);
             }
 
+            if (await Tank.Interrupt(GunbreakerSettings.Instance)) return true;
             if (await SingleTarget.RoughDivide()) return true;
-
 
             if (Utilities.Routines.Gunbreaker.OnGcd)
             {

--- a/Magitek/Rotations/Machinist.cs
+++ b/Magitek/Rotations/Machinist.cs
@@ -98,7 +98,7 @@ namespace Magitek.Rotations
             if (await Utility.Tactician()) return true;
             if (await PhysicalDps.ArmsLength(MachinistSettings.Instance)) return true;
             if (await PhysicalDps.SecondWind(MachinistSettings.Instance)) return true;
-            if (await Utility.HeadGraze()) return true;
+            if (await PhysicalDps.Interrupt(MachinistSettings.Instance)) return true;
 
             if (Weaving.GetCurrentWeavingCounter() < 2)
             {

--- a/Magitek/Rotations/Monk.cs
+++ b/Magitek/Rotations/Monk.cs
@@ -104,6 +104,7 @@ namespace Magitek.Rotations
             {
                 if (Weaving.GetCurrentWeavingCounter() < 2 && Spells.Bootshine.Cooldown.TotalMilliseconds > 750 + BaseSettings.Instance.UserLatencyOffset)
                 {
+                    if (await PhysicalDps.Interrupt(MonkSettings.Instance)) return true;
                     if (await PhysicalDps.SecondWind(MonkSettings.Instance)) return true;
                     if (await PhysicalDps.Bloodbath(MonkSettings.Instance)) return true;
                     if (await PhysicalDps.Feint(MonkSettings.Instance)) return true;

--- a/Magitek/Rotations/Ninja.cs
+++ b/Magitek/Rotations/Ninja.cs
@@ -87,11 +87,10 @@ namespace Magitek.Rotations
 
             if (await CustomOpenerLogic.Opener()) return true;
 
-
-            if (await PhysicalDps.Interrupt(NinjaSettings.Instance)) return true;
-
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
+
+            if (await PhysicalDps.Interrupt(NinjaSettings.Instance)) return true;
 
             //if (Core.Me.HasAura(Auras.TenChiJin))
             //{

--- a/Magitek/Rotations/Paladin.cs
+++ b/Magitek/Rotations/Paladin.cs
@@ -8,6 +8,7 @@ using Magitek.Models.Paladin;
 using Magitek.Utilities;
 using System.Linq;
 using System.Threading.Tasks;
+using Auras = Magitek.Utilities.Auras;
 
 namespace Magitek.Rotations
 {
@@ -79,8 +80,7 @@ namespace Magitek.Rotations
             if (!Core.Me.HasAura(Auras.PassageOfArms))
             {
                 if (await Buff.Oath()) return true;
-                if (await Tank.Interrupt(PaladinSettings.Instance)) return true;
-                if (await SingleTarget.ShieldBash()) return true;
+                if (await SingleTarget.Interrupt()) return true;
 
                 if (Utilities.Routines.Paladin.OnGcd)
                 {
@@ -108,6 +108,7 @@ namespace Magitek.Rotations
                 if (await SingleTarget.Atonement()) return true;
 
 
+                //TODO: Paladin rotation gets stuck after RiotBlade at level 59
                 if (ActionManager.LastSpell == Spells.RiotBlade && Core.Me.ClassLevel > 25 && Core.Me.ClassLevel < 60)
                 {
                     return await Spells.RageofHalone.Cast(Core.Me.CurrentTarget);

--- a/Magitek/Rotations/Samurai.cs
+++ b/Magitek/Rotations/Samurai.cs
@@ -2,7 +2,9 @@
 using ff14bot.Managers;
 using Magitek.Extensions;
 using Magitek.Logic;
+using Magitek.Logic.Roles;
 using Magitek.Logic.Samurai;
+using Magitek.Models.Samurai;
 using Magitek.Utilities;
 using System.Linq;
 using System.Threading.Tasks;
@@ -88,6 +90,7 @@ namespace Magitek.Rotations
             if (Utilities.Routines.Samurai.OnGcd)
             {
                 //Only cast spells that are instant/off gcd
+                if (await PhysicalDps.Interrupt(SamuraiSettings.Instance)) return true;
                 if (await SingleTarget.MidareSetsugekka()) return true;
                 if (await Aoe.TenkaGoken()) return true;
                 if (await SingleTarget.Higanbana()) return true;

--- a/Magitek/Utilities/Casting.cs
+++ b/Magitek/Utilities/Casting.cs
@@ -228,7 +228,8 @@ namespace Magitek.Utilities
             SpellCastHistory.Insert(0, new SpellCastHistoryItem { Spell = LastSpell,
                                                                   SpellTarget = SpellTarget,
                                                                   TimeCastUtc = LastSpellTimeFinishedUtc,
-                                                                  TimeStartedUtc = LastSpellTimeFinishedUtc.Subtract(TimeSpan.FromMilliseconds(CastingTime.ElapsedMilliseconds)) });
+                                                                  TimeStartedUtc = LastSpellTimeFinishedUtc.Subtract(TimeSpan.FromMilliseconds(CastingTime.ElapsedMilliseconds)),
+                                                                  DelayMs = CastingTime.ElapsedMilliseconds - SpellCastTime.TotalMilliseconds });
 
             if (BaseSettings.Instance.DebugSpellCastHistory)
                 Application.Current.Dispatcher.Invoke(delegate { Debug.Instance.SpellCastHistory = new List<SpellCastHistoryItem>(SpellCastHistory); });
@@ -278,12 +279,13 @@ namespace Magitek.Utilities
         public GameObject SpellTarget { get; set; }
         public DateTime TimeCastUtc { get; set; }
         public DateTime TimeStartedUtc { get; set; }
+        public double DelayMs { get; set; }
 
         public int AnimationLockRemainingMs
         {
             get
             {
-                double timeSinceStartMs = DateTime.UtcNow.Subtract(TimeStartedUtc).TotalMilliseconds;
+                double timeSinceStartMs = DateTime.UtcNow.Subtract(TimeStartedUtc).TotalMilliseconds - DelayMs;
                 return timeSinceStartMs > Globals.AnimationLockMs ? 0 : Globals.AnimationLockMs - (int)timeSinceStartMs;
             }
         }

--- a/Magitek/Views/UserControls/Bard/Utilities.xaml
+++ b/Magitek/Views/UserControls/Bard/Utilities.xaml
@@ -86,12 +86,10 @@
             </StackPanel>
         </controls:SettingsBlock>
 
-        <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
-            <StackPanel Margin="5">
-                <StackPanel  Orientation="Vertical">
-                    <CheckBox Content="Use Head Graze To Interrupt" IsChecked="{Binding BardSettings.UseHeadGraze, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                    <CheckBox Content="Only Interrupt Current Target" IsChecked="{Binding BardSettings.OnlyInterruptCurrentTarget, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                </StackPanel>
+        <controls:SettingsBlock Margin="0,5,0,0" Background="{DynamicResource ClassSelectorBackground}">
+            <StackPanel Margin="5" Orientation="Horizontal">
+                <TextBlock VerticalAlignment="Center" Margin="0,0,3,0" Style="{DynamicResource TextBlockDefault}" Text="Interrupt Strategy:" />
+                <ComboBox Width="170" ItemsSource="{Binding Source={StaticResource InterruptStrategy}}" SelectedValue="{Binding BardSettings.Strategy, Mode=TwoWay}" Style="{DynamicResource ComboBox}" />
             </StackPanel>
         </controls:SettingsBlock>
     </StackPanel>

--- a/Magitek/Views/UserControls/Dancer/SingleTarget.xaml
+++ b/Magitek/Views/UserControls/Dancer/SingleTarget.xaml
@@ -43,13 +43,12 @@
         </controls:SettingsBlock>
 
         <controls:SettingsBlock Margin="0,5,0,0" Background="{DynamicResource ClassSelectorBackground}">
-            <StackPanel Margin="5">
-                <StackPanel Orientation="Horizontal">
-                    <TextBlock Margin="0,0,10,0" Style="{DynamicResource TextBlockDefault}" Text="Selected Interrupt Strategy:" />
-                    <ComboBox Width="170" ItemsSource="{Binding Source={StaticResource InterruptStrategy}}" SelectedValue="{Binding DancerSettings.Strategy, Mode=TwoWay}" Style="{DynamicResource ComboBox}" />
-                </StackPanel>
+            <StackPanel Margin="5" Orientation="Horizontal">
+                <TextBlock VerticalAlignment="Center" Margin="0,0,3,0" Style="{DynamicResource TextBlockDefault}" Text="Interrupt Strategy:" />
+                <ComboBox Width="170" ItemsSource="{Binding Source={StaticResource InterruptStrategy}}" SelectedValue="{Binding DancerSettings.Strategy, Mode=TwoWay}" Style="{DynamicResource ComboBox}" />
             </StackPanel>
         </controls:SettingsBlock>
     </StackPanel>
+
 </UserControl>
 

--- a/Magitek/Views/UserControls/DarkKnight/Combat.xaml
+++ b/Magitek/Views/UserControls/DarkKnight/Combat.xaml
@@ -84,21 +84,12 @@
             </StackPanel>
         </controls:SettingsBlock>
 
-        <controls:SettingsBlock Background="{DynamicResource ClassSelectorBackground}">
-            <StackPanel Margin="5">
-                <Grid>
-                    <Grid.RowDefinitions>
-                        <RowDefinition />
-                        <RowDefinition />
-                    </Grid.RowDefinitions>
-                    <CheckBox Grid.Row="0" Content="Use Interrupt " IsChecked="{Binding WarriorSettings.UseInterrupt, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-
-                    <StackPanel Margin="0,5,0,0" Grid.Row="1" Orientation="Horizontal">
-                        <TextBlock Margin="0,0,10,0" Style="{DynamicResource TextBlockDefault}" Text="Selected Interrupt Strategy:" />
-                        <ComboBox Width="170" ItemsSource="{Binding Source={StaticResource InterruptStrategy}}" SelectedValue="{Binding WarriorSettings.Strategy, Mode=TwoWay}" Style="{DynamicResource ComboBox}" />
-                    </StackPanel>
-                </Grid>
+        <controls:SettingsBlock Margin="0,5,0,0" Background="{DynamicResource ClassSelectorBackground}">
+            <StackPanel Margin="5" Orientation="Horizontal">
+                <TextBlock VerticalAlignment="Center" Margin="0,0,3,0" Style="{DynamicResource TextBlockDefault}" Text="Interrupt and Stun Strategy:" />
+                <ComboBox Width="170" ItemsSource="{Binding Source={StaticResource InterruptStrategy}}" SelectedValue="{Binding DarkKnightSettings.Strategy, Mode=TwoWay}" Style="{DynamicResource ComboBox}" />
             </StackPanel>
         </controls:SettingsBlock>
+
     </StackPanel>
 </UserControl>

--- a/Magitek/Views/UserControls/Dragoon/SingleTarget.xaml
+++ b/Magitek/Views/UserControls/Dragoon/SingleTarget.xaml
@@ -1,12 +1,24 @@
 ﻿<UserControl x:Class="Magitek.Views.UserControls.Dragoon.SingleTarget"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:sys="clr-namespace:System;assembly=mscorlib"
              xmlns:controls="clr-namespace:Magitek.Controls"
+             xmlns:enums="clr-namespace:Magitek.Enumerations"
              xmlns:viewModels="clr-namespace:Magitek.ViewModels">
 
     <UserControl.DataContext>
         <Binding Source="{x:Static viewModels:BaseSettings.Instance}" />
     </UserControl.DataContext>
+
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ObjectDataProvider x:Key="InterruptStrategy" MethodName="GetValues" ObjectType="{x:Type sys:Enum}">
+                <ObjectDataProvider.MethodParameters>
+                    <x:Type TypeName="enums:InterruptStrategy" />
+                </ObjectDataProvider.MethodParameters>
+            </ObjectDataProvider>
+        </ResourceDictionary>
+    </UserControl.Resources>
 
     <StackPanel Margin="10">
 
@@ -18,9 +30,10 @@
             </StackPanel>
         </controls:SettingsBlock>
 
-        <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
-            <StackPanel Margin="5">
-                <CheckBox Content="Stun" IsChecked="{Binding DragoonSettings.Stun, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+        <controls:SettingsBlock Margin="0,0,0,5" Background="{DynamicResource ClassSelectorBackground}">
+            <StackPanel Margin="5" Orientation="Horizontal">
+                <TextBlock VerticalAlignment="Center" Margin="0,0,3,0" Style="{DynamicResource TextBlockDefault}" Text="Stun Strategy:" />
+                <ComboBox Width="170" ItemsSource="{Binding Source={StaticResource InterruptStrategy}}" SelectedValue="{Binding DragoonSettings.Strategy, Mode=TwoWay}" Style="{DynamicResource ComboBox}" />
             </StackPanel>
         </controls:SettingsBlock>
 

--- a/Magitek/Views/UserControls/Gunbreaker/Combat.xaml
+++ b/Magitek/Views/UserControls/Gunbreaker/Combat.xaml
@@ -116,20 +116,10 @@
             </Grid>
         </controls:SettingsBlock>
 
-        <controls:SettingsBlock Background="{DynamicResource ClassSelectorBackground}">
-            <StackPanel Margin="5">
-                <Grid>
-                    <Grid.RowDefinitions>
-                        <RowDefinition />
-                        <RowDefinition />
-                    </Grid.RowDefinitions>
-                    <CheckBox Grid.Row="0" Content="Use Interrupt " IsChecked="{Binding WarriorSettings.UseInterrupt, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-
-                    <StackPanel Margin="0,5,0,0" Grid.Row="1" Orientation="Horizontal">
-                        <TextBlock Margin="0,0,10,0" Style="{DynamicResource TextBlockDefault}" Text="Selected Interrupt Strategy:" />
-                        <ComboBox Width="170" ItemsSource="{Binding Source={StaticResource InterruptStrategy}}" SelectedValue="{Binding WarriorSettings.Strategy, Mode=TwoWay}" Style="{DynamicResource ComboBox}" />
-                    </StackPanel>
-                </Grid>
+        <controls:SettingsBlock Margin="0,5,0,0" Background="{DynamicResource ClassSelectorBackground}">
+            <StackPanel Margin="5" Orientation="Horizontal">
+                <TextBlock VerticalAlignment="Center" Margin="0,0,3,0" Style="{DynamicResource TextBlockDefault}" Text="Interrupt and Stun Strategy:" />
+                <ComboBox Width="170" ItemsSource="{Binding Source={StaticResource InterruptStrategy}}" SelectedValue="{Binding GunbreakerSettings.Strategy, Mode=TwoWay}" Style="{DynamicResource ComboBox}" />
             </StackPanel>
         </controls:SettingsBlock>
 

--- a/Magitek/Views/UserControls/Machinist/SingleTarget.xaml
+++ b/Magitek/Views/UserControls/Machinist/SingleTarget.xaml
@@ -2,23 +2,11 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:controls="clr-namespace:Magitek.Controls"
-             xmlns:enums="clr-namespace:Magitek.Enumerations"
-             xmlns:sys="clr-namespace:System;assembly=mscorlib"
              xmlns:viewModels="clr-namespace:Magitek.ViewModels">
 
     <UserControl.DataContext>
         <Binding Source="{x:Static viewModels:BaseSettings.Instance}" />
     </UserControl.DataContext>
-
-    <UserControl.Resources>
-        <ResourceDictionary>
-            <ObjectDataProvider x:Key="InterruptStrategy" MethodName="GetValues" ObjectType="{x:Type sys:Enum}">
-                <ObjectDataProvider.MethodParameters>
-                    <x:Type TypeName="enums:InterruptStrategy" />
-                </ObjectDataProvider.MethodParameters>
-            </ObjectDataProvider>
-        </ResourceDictionary>
-    </UserControl.Resources>
 
     <StackPanel Margin="10">
         <controls:SettingsBlock Background="{DynamicResource ClassSelectorBackground}">
@@ -54,13 +42,5 @@
             </StackPanel>
         </controls:SettingsBlock>
 
-        <controls:SettingsBlock Margin="0,5,0,0" Background="{DynamicResource ClassSelectorBackground}">
-            <StackPanel Margin="5">
-                <StackPanel Orientation="Horizontal">
-                    <TextBlock Margin="0,0,10,0" Style="{DynamicResource TextBlockDefault}" Text="Selected Interrupt Strategy:" />
-                    <ComboBox Width="170" ItemsSource="{Binding Source={StaticResource InterruptStrategy}}" SelectedValue="{Binding MachinistSettings.Strategy, Mode=TwoWay}" Style="{DynamicResource ComboBox}" />
-                </StackPanel>
-            </StackPanel>
-        </controls:SettingsBlock>
     </StackPanel>
 </UserControl>

--- a/Magitek/Views/UserControls/Machinist/Utilities.xaml
+++ b/Magitek/Views/UserControls/Machinist/Utilities.xaml
@@ -47,14 +47,13 @@
             </Grid>
         </controls:SettingsBlock>
 
-        <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
-            <StackPanel Margin="5">
-                <StackPanel  Orientation="Vertical">
-                    <CheckBox Content="Use Head Graze To Interrupt" IsChecked="{Binding MachinistSettings.UseHeadGraze, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                    <CheckBox Content="Only Interrupt Current Target" IsChecked="{Binding MachinistSettings.OnlyInterruptCurrentTarget, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                </StackPanel>
+        <controls:SettingsBlock Margin="0,5,0,0" Background="{DynamicResource ClassSelectorBackground}">
+            <StackPanel Margin="5" Orientation="Horizontal">
+                <TextBlock VerticalAlignment="Center" Margin="0,0,3,0" Style="{DynamicResource TextBlockDefault}" Text="Interrupt Strategy:" />
+                <ComboBox Width="170" ItemsSource="{Binding Source={StaticResource InterruptStrategy}}" SelectedValue="{Binding MachinistSettings.Strategy, Mode=TwoWay}" Style="{DynamicResource ComboBox}" />
             </StackPanel>
         </controls:SettingsBlock>
+
     </StackPanel>
 </UserControl>
 

--- a/Magitek/Views/UserControls/Monk/SingleTarget.xaml
+++ b/Magitek/Views/UserControls/Monk/SingleTarget.xaml
@@ -4,10 +4,22 @@
              xmlns:controls="clr-namespace:Magitek.Controls"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:sys="clr-namespace:System;assembly=mscorlib"
+             xmlns:enums="clr-namespace:Magitek.Enumerations"
              xmlns:viewModels="clr-namespace:Magitek.ViewModels"
              d:DesignHeight="400"
              d:DesignWidth="500"
              mc:Ignorable="d">
+
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ObjectDataProvider x:Key="InterruptStrategy" MethodName="GetValues" ObjectType="{x:Type sys:Enum}">
+                <ObjectDataProvider.MethodParameters>
+                    <x:Type TypeName="enums:InterruptStrategy" />
+                </ObjectDataProvider.MethodParameters>
+            </ObjectDataProvider>
+        </ResourceDictionary>
+    </UserControl.Resources>
 
     <UserControl.DataContext>
         <Binding Source="{x:Static viewModels:BaseSettings.Instance}" />
@@ -142,6 +154,13 @@
         <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
             <StackPanel Margin="5" Orientation="Horizontal">
                 <CheckBox Content="Shoulder Tackle" IsChecked="{Binding MonkSettings.UseShoulderTackle, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+            </StackPanel>
+        </controls:SettingsBlock>
+
+        <controls:SettingsBlock Background="{DynamicResource ClassSelectorBackground}">
+            <StackPanel Margin="5" Orientation="Horizontal">
+                <TextBlock VerticalAlignment="Center" Margin="0,0,3,0" Style="{DynamicResource TextBlockDefault}" Text="Stun Strategy:" />
+                <ComboBox Width="170" ItemsSource="{Binding Source={StaticResource InterruptStrategy}}" SelectedValue="{Binding MonkSettings.Strategy, Mode=TwoWay}" Style="{DynamicResource ComboBox}" />
             </StackPanel>
         </controls:SettingsBlock>
     </StackPanel>

--- a/Magitek/Views/UserControls/Ninja/SingleTarget.xaml
+++ b/Magitek/Views/UserControls/Ninja/SingleTarget.xaml
@@ -127,11 +127,9 @@
         </controls:SettingsBlock>
 
         <controls:SettingsBlock Margin="0,5,0,0" Background="{DynamicResource ClassSelectorBackground}">
-            <StackPanel Margin="5">
-                <StackPanel Orientation="Horizontal">
-                    <TextBlock Margin="0,0,10,0" Style="{DynamicResource TextBlockDefault}" Text="Selected Interrupt Strategy:" />
-                    <ComboBox Width="170" ItemsSource="{Binding Source={StaticResource InterruptStrategy}}" SelectedValue="{Binding BardSettings.Strategy, Mode=TwoWay}" Style="{DynamicResource ComboBox}" />
-                </StackPanel>
+            <StackPanel Margin="5" Orientation="Horizontal">
+                <TextBlock VerticalAlignment="Center" Margin="0,0,3,0" Style="{DynamicResource TextBlockDefault}" Text="Stun Strategy:" />
+                <ComboBox Width="170" ItemsSource="{Binding Source={StaticResource InterruptStrategy}}" SelectedValue="{Binding NinjaSettings.Strategy, Mode=TwoWay}" Style="{DynamicResource ComboBox}" />
             </StackPanel>
         </controls:SettingsBlock>
 

--- a/Magitek/Views/UserControls/Paladin/Combat.xaml
+++ b/Magitek/Views/UserControls/Paladin/Combat.xaml
@@ -116,15 +116,13 @@
             </StackPanel>
         </controls:SettingsBlock>
 
-        <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
+        <controls:SettingsBlock Margin="0,5,0,0" Background="{DynamicResource ClassSelectorBackground}">
             <StackPanel Margin="5">
-                <CheckBox Margin="0,3,0,0" Content="Use Stun" IsChecked="{Binding PaladinSettings.UseInterrupt, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                <CheckBox Margin="24,3,0,0" Content="Stun with Shield Bash" IsChecked="{Binding PaladinSettings.ShieldBash, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                <CheckBox Content="Use Interrupt" IsChecked="{Binding PaladinSettings.UseInterject, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                 <StackPanel Orientation="Horizontal">
-                    <TextBlock Margin="0,0,10,0" Style="{DynamicResource TextBlockDefault}" Text="Selected Interrupt Strategy:" />
+                    <TextBlock VerticalAlignment="Center" Margin="0,0,3,0" Style="{DynamicResource TextBlockDefault}" Text="Interrupt and Stun Strategy:" />
                     <ComboBox Width="170" ItemsSource="{Binding Source={StaticResource InterruptStrategy}}" SelectedValue="{Binding PaladinSettings.Strategy, Mode=TwoWay}" Style="{DynamicResource ComboBox}" />
                 </StackPanel>
+                <CheckBox Margin="0,3,0,0" Content="Use Shield Bash" IsChecked="{Binding PaladinSettings.ShieldBash, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
             </StackPanel>
         </controls:SettingsBlock>
 

--- a/Magitek/Views/UserControls/Paladin/TankSwap.xaml
+++ b/Magitek/Views/UserControls/Paladin/TankSwap.xaml
@@ -1,13 +1,25 @@
 ﻿<UserControl x:Class="Magitek.Views.UserControls.Paladin.TankSwap"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:sys="clr-namespace:System;assembly=mscorlib"
              xmlns:controls="clr-namespace:Magitek.Controls"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:viewModels="clr-namespace:Magitek.ViewModels"
+             xmlns:enums="clr-namespace:Magitek.Enumerations"
              d:DesignHeight="400"
              d:DesignWidth="500"
              mc:Ignorable="d">
+
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ObjectDataProvider x:Key="InterruptStrategy" MethodName="GetValues" ObjectType="{x:Type sys:Enum}">
+                <ObjectDataProvider.MethodParameters>
+                    <x:Type TypeName="enums:InterruptStrategy" />
+                </ObjectDataProvider.MethodParameters>
+            </ObjectDataProvider>
+        </ResourceDictionary>
+    </UserControl.Resources>
 
     <UserControl.DataContext>
         <Binding Source="{x:Static viewModels:BaseSettings.Instance}" />
@@ -21,67 +33,75 @@
             </StackPanel>
         </controls:SettingsBlock>
 
-        <controls:SettingsBlock Margin="0,0,0,1" Background="{DynamicResource ClassSelectorBackground}">
-            <StackPanel Margin="5" Orientation="Horizontal">
-                <Image Source="https://ffxiv.gamerescape.com/w/images/thumb/e/ee/Sword_Oath_Icon.png/48px-Sword_Oath_Icon.png" Width="20"></Image>
-            <TextBox Margin="5,0,0,0" Background="{DynamicResource ClassSelectorBackground}" FontWeight="Black" Foreground="White" BorderThickness="0" BorderBrush="Black">Sword Oath</TextBox>
-             </StackPanel>
+        <controls:SettingsBlock Margin="0,0,0,5" Background="{DynamicResource ClassSelectorBackground}">
+            <Grid Margin="3">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition/>
+                    <ColumnDefinition/>
+                    <ColumnDefinition/>
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition/>
+                    <RowDefinition/>
+                    <RowDefinition/>
+                    <RowDefinition/>
+                    <RowDefinition/>
+                </Grid.RowDefinitions>
+                <StackPanel Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3" Margin="0,1,0,0" Orientation="Horizontal">
+                    <Image Margin="1,0,5,0" Source="https://ffxiv.gamerescape.com/w/images/thumb/e/ee/Sword_Oath_Icon.png/48px-Sword_Oath_Icon.png" Width="20"></Image>
+                    <TextBox Background="{DynamicResource ClassSelectorBackground}" FontWeight="Black" Foreground="White" BorderThickness="0" BorderBrush="Black">Sword Oath</TextBox>
+                </StackPanel>
+
+                <CheckBox Grid.Row="1" Grid.Column="0" Content="Use Defensives" IsChecked="{Binding PaladinSettings.SwordDefensive, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                <CheckBox Grid.Row="1" Grid.Column="1" Content="Use Clemency" IsChecked="{Binding PaladinSettings.SwordClemency, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                <CheckBox Grid.Row="1" Grid.Column="2" Content="Use Provoke" IsChecked="{Binding PaladinSettings.SwordProvoke, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+
+                <CheckBox Grid.Row="2" Grid.Column="0" Content="Use Shield Bash" IsChecked="{Binding PaladinSettings.SwordShieldBash, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                <CheckBox Grid.Row="2" Grid.Column="1" Content="Use Cover" IsChecked="{Binding PaladinSettings.SwordCover, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                <CheckBox Grid.Row="2" Grid.Column="2" Content="Pull Extra" IsChecked="{Binding PaladinSettings.SwordPullExtra, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+
+                <CheckBox Grid.Row="3" Grid.Column="0" Content="ShieldLob Aggro" IsChecked="{Binding PaladinSettings.SwordShieldLob, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                <CheckBox Grid.Row="3" Grid.Column="1" Content="Requiescat" IsChecked="{Binding PaladinSettings.SwordRequiecast, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+
+                <TextBlock Grid.Row="4" Grid.Column="0" Margin="0,0,3,0" VerticalAlignment="Center" Style="{DynamicResource TextBlockDefault}" Text="Interrupt and Stun Strategy:" />
+                <ComboBox Grid.Row="4" Grid.Column="1" ItemsSource="{Binding Source={StaticResource InterruptStrategy}}" SelectedValue="{Binding PaladinSettings.SwordStrategy, Mode=TwoWay}" Style="{DynamicResource ComboBox}" />
+            </Grid>
         </controls:SettingsBlock>
 
         <controls:SettingsBlock Margin="0,0,0,1" Background="{DynamicResource ClassSelectorBackground}">
-            <StackPanel Margin="5" Orientation="Horizontal">
-                <CheckBox Content="Use Defensives" IsChecked="{Binding PaladinSettings.SwordDefensive, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                <CheckBox Margin="20,3,0,0" Content="Use Clemency" IsChecked="{Binding PaladinSettings.SwordClemency, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                <CheckBox Margin="20,3,0,0" Content="Use Provoke" IsChecked="{Binding PaladinSettings.SwordProvoke, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-            </StackPanel>
-        </controls:SettingsBlock>
+            <Grid Margin="3">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition/>
+                    <ColumnDefinition/>
+                    <ColumnDefinition/>
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition/>
+                    <RowDefinition/>
+                    <RowDefinition/>
+                    <RowDefinition/>
+                    <RowDefinition/>
+                </Grid.RowDefinitions>
+                <StackPanel Grid.Row ="0" Grid.Column="0" Grid.ColumnSpan="3" Margin="0,1,0,0" Orientation="Horizontal">
+                    <Image Margin="1,0,5,0" Source="https://ffxiv.gamerescape.com/w/images/thumb/4/43/Shield_Oath_Icon.png/48px-Shield_Oath_Icon.png" Width="20"></Image>
+                    <TextBox Background="{DynamicResource ClassSelectorBackground}" FontWeight="Black" Foreground="White" BorderThickness="0" BorderBrush="Black">Shield Oath</TextBox>
+                </StackPanel>
 
-        <controls:SettingsBlock Margin="0,0,0,1" Background="{DynamicResource ClassSelectorBackground}">
-            <StackPanel Margin="5" Orientation="Horizontal">
-                <CheckBox Content="Use Interrupt" IsChecked="{Binding PaladinSettings.SwordInterrupt, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                <CheckBox Margin="30,3,0,0" Content="Use Shield Bash" IsChecked="{Binding PaladinSettings.SwordShieldBash, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                <CheckBox Margin="13,3,0,0" Content="Use Cover" IsChecked="{Binding PaladinSettings.SwordCover, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                <CheckBox Margin="15,3,0,0" Content="Pull Extra" IsChecked="{Binding PaladinSettings.SwordPullExtra, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-            </StackPanel>
-        </controls:SettingsBlock>
-        <controls:SettingsBlock Margin="0,0,0,1" Background="{DynamicResource ClassSelectorBackground}">
-            <StackPanel Margin="5" Orientation="Horizontal">
-                <CheckBox Margin="0,3,0,0" Content="ShieldLob Aggro" IsChecked="{Binding PaladinSettings.SwordShieldLob, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                <CheckBox Margin="12,3,0,0" Content="Requiescat" IsChecked="{Binding PaladinSettings.SwordRequiecast, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-            </StackPanel>
-        </controls:SettingsBlock>
+                <CheckBox Grid.Row="1" Grid.Column="0" Content="Use Defensives" IsChecked="{Binding PaladinSettings.ShieldDefensive, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                <CheckBox Grid.Row="1" Grid.Column="1" Content="Use Clemency" IsChecked="{Binding PaladinSettings.ShieldClemency, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                <CheckBox Grid.Row="1" Grid.Column="2" Content="Use Provoke" IsChecked="{Binding PaladinSettings.ShieldProvoke, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
 
-        <controls:SettingsBlock Margin="0,30,0,1" Background="{DynamicResource ClassSelectorBackground}">
-            <StackPanel Margin="5" Orientation="Horizontal">
-                <Image Source="https://ffxiv.gamerescape.com/w/images/thumb/4/43/Shield_Oath_Icon.png/48px-Shield_Oath_Icon.png" Width="20"></Image>
-                <TextBox Margin="5,0,0,0" Background="{DynamicResource ClassSelectorBackground}" FontWeight="Black" Foreground="White" BorderThickness="0" BorderBrush="Black">Shield Oath</TextBox>
-            </StackPanel>
-        </controls:SettingsBlock>
+                <CheckBox Grid.Row="2" Grid.Column="0" Content="Use Shield Bash" IsChecked="{Binding PaladinSettings.ShieldShieldBash, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                <CheckBox Grid.Row="2" Grid.Column="1" Content="Use Cover" IsChecked="{Binding PaladinSettings.ShieldCover, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                <CheckBox Grid.Row="2" Grid.Column="2" Content="Pull Extra" IsChecked="{Binding PaladinSettings.ShieldPullExtra, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
 
-        <controls:SettingsBlock Margin="0,0,0,1" Background="{DynamicResource ClassSelectorBackground}">
-            <StackPanel Margin="5" Orientation="Horizontal">
-                <CheckBox Content="Use Defensives" IsChecked="{Binding PaladinSettings.ShieldDefensive, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                <CheckBox Margin="20,3,0,0" Content="Use Clemency" IsChecked="{Binding PaladinSettings.ShieldClemency, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                <CheckBox Margin="20,3,0,0" Content="Use Provoke" IsChecked="{Binding PaladinSettings.ShieldProvoke, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-            </StackPanel>
-        </controls:SettingsBlock>
+                <CheckBox Grid.Row="3" Grid.Column="0" Content="ShieldLob Aggro" IsChecked="{Binding PaladinSettings.ShieldShieldLob, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                <CheckBox Grid.Row="3" Grid.Column="1" Content="Requiescat" IsChecked="{Binding PaladinSettings.ShieldRequiecast, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
 
-        <controls:SettingsBlock Margin="0,0,0,1" Background="{DynamicResource ClassSelectorBackground}">
-            <StackPanel Margin="5" Orientation="Horizontal">
-                <CheckBox Content="Use Interrupt" IsChecked="{Binding PaladinSettings.ShieldInterrupt, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                <CheckBox Margin="30,3,0,0" Content="Use Shield Bash" IsChecked="{Binding PaladinSettings.ShieldShieldBash, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                <CheckBox Margin="13,3,0,0" Content="Use Cover" IsChecked="{Binding PaladinSettings.ShieldCover, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                <CheckBox Margin="15,3,0,0" Content="Pull Extra" IsChecked="{Binding PaladinSettings.ShieldPullExtra, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-            </StackPanel>
+                <TextBlock Grid.Row="4" Grid.Column="0" Margin="0,0,3,0" VerticalAlignment="Center" Style="{DynamicResource TextBlockDefault}" Text="Interrupt and Stun Strategy:" />
+                <ComboBox Grid.Row="4" Grid.Column="1" ItemsSource="{Binding Source={StaticResource InterruptStrategy}}" SelectedValue="{Binding PaladinSettings.ShieldStrategy, Mode=TwoWay}" Style="{DynamicResource ComboBox}" />
+            </Grid>
         </controls:SettingsBlock>
-        <controls:SettingsBlock Margin="0,0,0,1" Background="{DynamicResource ClassSelectorBackground}">
-            <StackPanel Margin="5" Orientation="Horizontal">
-                <CheckBox Margin="0,3,0,0" Content="ShieldLob Aggro" IsChecked="{Binding PaladinSettings.ShieldShieldLob, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                <CheckBox Margin="12,3,0,0" Content="Requiescat" IsChecked="{Binding PaladinSettings.ShieldRequiecast, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-            </StackPanel>
-        </controls:SettingsBlock>
-
-
 
     </StackPanel>
 

--- a/Magitek/Views/UserControls/Samurai/SingleTarget.xaml
+++ b/Magitek/Views/UserControls/Samurai/SingleTarget.xaml
@@ -1,8 +1,20 @@
 ﻿<UserControl x:Class="Magitek.Views.UserControls.Samurai.SingleTarget" 
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 
+             xmlns:sys="clr-namespace:System;assembly=mscorlib"
              xmlns:controls="clr-namespace:Magitek.Controls" 
+             xmlns:enums="clr-namespace:Magitek.Enumerations"
              xmlns:viewModels="clr-namespace:Magitek.ViewModels">
+
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ObjectDataProvider x:Key="InterruptStrategy" MethodName="GetValues" ObjectType="{x:Type sys:Enum}">
+                <ObjectDataProvider.MethodParameters>
+                    <x:Type TypeName="enums:InterruptStrategy" />
+                </ObjectDataProvider.MethodParameters>
+            </ObjectDataProvider>
+        </ResourceDictionary>
+    </UserControl.Resources>
 
     <UserControl.DataContext>
         <Binding Source="{x:Static viewModels:BaseSettings.Instance}" />
@@ -61,6 +73,13 @@
                 <StackPanel Margin="5,0,0,0" Orientation="Horizontal">
                     <TextBlock Style="{DynamicResource TextBlockDefault}" Text="~500-1000ms to attempt to double weave, 1000+ to only single weave" FontSize="8" />
                 </StackPanel>
+            </StackPanel>
+        </controls:SettingsBlock>
+
+        <controls:SettingsBlock Margin="0,5,0,0" Background="{DynamicResource ClassSelectorBackground}">
+            <StackPanel Margin="5" Orientation="Horizontal">
+                <TextBlock VerticalAlignment="Center" Margin="0,0,3,0" Style="{DynamicResource TextBlockDefault}" Text="Stun Strategy:" />
+                <ComboBox Width="170" ItemsSource="{Binding Source={StaticResource InterruptStrategy}}" SelectedValue="{Binding SamuraiSettings.Strategy, Mode=TwoWay}" Style="{DynamicResource ComboBox}" />
             </StackPanel>
         </controls:SettingsBlock>
 

--- a/Magitek/Views/UserControls/Warrior/Combat.xaml
+++ b/Magitek/Views/UserControls/Warrior/Combat.xaml
@@ -40,20 +40,10 @@
             </StackPanel>
         </controls:SettingsBlock>
 
-        <controls:SettingsBlock Background="{DynamicResource ClassSelectorBackground}">
-            <StackPanel Margin="5">
-                <Grid>
-                    <Grid.RowDefinitions>
-                        <RowDefinition />
-                        <RowDefinition />
-                    </Grid.RowDefinitions>
-                    <CheckBox Grid.Row="0" Content="Use Interrupt " IsChecked="{Binding WarriorSettings.UseInterrupt, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-
-                    <StackPanel Margin="0,5,0,0" Grid.Row="1" Orientation="Horizontal">
-                        <TextBlock Margin="0,0,10,0" Style="{DynamicResource TextBlockDefault}" Text="Selected Interrupt Strategy:" />
-                        <ComboBox Width="170" ItemsSource="{Binding Source={StaticResource InterruptStrategy}}" SelectedValue="{Binding WarriorSettings.Strategy, Mode=TwoWay}" Style="{DynamicResource ComboBox}" />
-                    </StackPanel>
-                </Grid>
+        <controls:SettingsBlock Margin="0,5,0,0" Background="{DynamicResource ClassSelectorBackground}">
+            <StackPanel Margin="5" Orientation="Horizontal">
+                <TextBlock VerticalAlignment="Center" Margin="0,0,3,0" Style="{DynamicResource TextBlockDefault}" Text="Interrupt and Stun Strategy:" />
+                <ComboBox Width="170" ItemsSource="{Binding Source={StaticResource InterruptStrategy}}" SelectedValue="{Binding WarriorSettings.Strategy, Mode=TwoWay}" Style="{DynamicResource ComboBox}" />
             </StackPanel>
         </controls:SettingsBlock>
 


### PR DESCRIPTION
Sorry for the size of this PR. It touches a lot of files because I redid the config code for stuns & interrupts on all applicable classes.
The new code is now used by all tank, melee DPS, and physical ranged DPS classes. There's only a single setting to configure it, and they all use that one setting. They also all call into the same stun/interrupt logic. It's all centralized now and should be much easier to maintain.
Changes:
- Refactored interrupt and stun code to a common location
- Updated all physical DPS and tank classes to be able to stun or interrupt, per class configuration
- Updated and simplified interrupt & stun configuration on all classes
- Improved timing on stun/interrupt logic
- Removed use of SpellData.Range, because it sometimes lies