### PR TITLE
DRG: Don't do nothing trying to AoE below lvl 40

### DIFF
--- a/Magitek/Rotations/Dragoon.cs
+++ b/Magitek/Rotations/Dragoon.cs
@@ -208,7 +208,7 @@ namespace Magitek.Rotations
             if (await SingleTarget.WheelingThrust()) return true;
             if (await SingleTarget.FangAndClaw()) return true;
 
-            if (DragoonSettings.Instance.Aoe && Core.Me.CurrentTarget.EnemiesNearby(8).Count() >= DragoonSettings.Instance.AoeEnemies)
+            if (DragoonSettings.Instance.Aoe && Core.Me.CurrentTarget.EnemiesNearby(8).Count() >= DragoonSettings.Instance.AoeEnemies && Core.Me.ClassLevel >= Spells.DoomSpike.LevelAcquired)
             {
                 if (await Aoe.CoethanTorment()) return true;
                 if (await Aoe.SonicThrust()) return true;


### PR DESCRIPTION
When below level 40 and fighting enough enemies to trigger AoE mode, the DRG rotation would just stop, because it would only try to use AoE abilities, and there aren't any below level 40.