### PR TITLE
GNB: Fix 6s freeze after using Reprisal

### DIFF
--- a/Magitek/Utilities/Auras.cs
+++ b/Magitek/Utilities/Auras.cs
@@ -91,7 +91,7 @@ namespace Magitek.Utilities
             ShadowWall = 747,
             SaltedEarth = 749,
             Darkside = 751,
-            Reprisal = 753,
+            Reprisal = 1193,
             LivingDead = 810,
             DragonKick = 98,
             TwinSnakes = 101,


### PR DESCRIPTION
When using reprisal, it was waiting for the "Reprisal" aura to appear on the target before deciding the spell cast was complete. Unfortunately, there's more than one "Reprisal" aura, and it was waiting for the wrong one. After a timeout of 6s, the rotation continued about its way. I've updated it to look for the correct aura now.