### PR TITLE
SCH fix for ET and other things

### DIFF
--- a/Magitek/Converters/ConditionAddConverter.cs
+++ b/Magitek/Converters/ConditionAddConverter.cs
@@ -18,7 +18,7 @@ namespace Magitek.Converters
                 var conditionType = (string)values[1];
                 return new Tuple<Gambit, string>(gambit, conditionType);
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 // catching and doing nothing with an exception here because for whatever reason WPF decides
                 // to go through every converter on every ICommand action causing exceptions on some of the commands. 

--- a/Magitek/Converters/GambitOrderPositionConverter.cs
+++ b/Magitek/Converters/GambitOrderPositionConverter.cs
@@ -18,7 +18,7 @@ namespace Magitek.Converters
                 var gambit = (Gambit)values[1];
                 return new Tuple<GambitGroup, Gambit>(gambitGroup, gambit);
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 // catching and doing nothing with an exception here because for whatever reason WPF decides
                 // to go through every converter on every ICommand action causing exceptions on some of the commands. 

--- a/Magitek/Converters/OpenerConditionAddConverter.cs
+++ b/Magitek/Converters/OpenerConditionAddConverter.cs
@@ -18,7 +18,7 @@ namespace Magitek.Converters
                 var conditionType = (string)values[1];
                 return new Tuple<OpenerGroup, string>(openerGroup, conditionType);
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 // catching and doing nothing with an exception here because for whatever reason WPF decides
                 // to go through every converter on every ICommand action causing exceptions on some of the commands. 

--- a/Magitek/Converters/OpenerOrderPositionConverter.cs
+++ b/Magitek/Converters/OpenerOrderPositionConverter.cs
@@ -18,7 +18,7 @@ namespace Magitek.Converters
                 var gambit = (Gambit)values[1];
                 return new Tuple<OpenerGroup, Gambit>(openerGroup, gambit);
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 // catching and doing nothing with an exception here because for whatever reason WPF decides
                 // to go through every converter on every ICommand action causing exceptions on some of the commands. 

--- a/Magitek/Logic/Astrologian/Heal.cs
+++ b/Magitek/Logic/Astrologian/Heal.cs
@@ -684,6 +684,9 @@ namespace Magitek.Logic.Astrologian
             if (Combat.CombatTotalTimeLeft < 15)
                 return false;
 
+            if (Spells.EarthlyStar.Cooldown != TimeSpan.Zero)
+                return false;
+
             var earthlyStarLocation = Utilities.Routines.Astrologian.EarthlyStarLocation;
 
             var earthlyStarTargets = PartyManager.VisibleMembers.Select(r => r.BattleCharacter).ToList();

--- a/Magitek/Logic/GambitLogic.cs
+++ b/Magitek/Logic/GambitLogic.cs
@@ -41,7 +41,7 @@ namespace Magitek.Logic
                             ForbiddenGambits.Remove(gambit.Key);
                     }
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
                     // Ignore that shit
                 }
@@ -70,19 +70,15 @@ namespace Magitek.Logic
                 if (!currentGambitExecutionStatus)
                     continue;
 
-                if (currentGambitExecutionStatus)
-                {
-                    Logger.WriteInfo($"Executed Gambit: {currentGambit.Title}");
+                Logger.WriteInfo($"Executed Gambit: {currentGambit.Title}");
 
-                    // make the current gambit forbidden if it has a timer
-                    if (currentGambit.PreventSameActionForTheNextMilliseconds > 0)
-                    {
-                        var timeExpired = DateTime.Now.AddMilliseconds(currentGambit.PreventSameActionForTheNextMilliseconds);
-                        ForbiddenGambits.Add(currentGambit.Id, timeExpired);
-                    }
+                // make the current gambit forbidden if it has a timer
+                if (currentGambit.PreventSameActionForTheNextMilliseconds > 0) {
+                    var timeExpired = DateTime.Now.AddMilliseconds(currentGambit.PreventSameActionForTheNextMilliseconds);
+                    ForbiddenGambits.Add(currentGambit.Id, timeExpired);
                 }
 
-                if (currentGambitExecutionStatus && currentGambit.HasChain)
+                if (currentGambit.HasChain)
                 {
                     // Start Chain
                     Logger.WriteInfo($"Starting Gambit Chain: {currentGambit.Title}");
@@ -142,13 +138,8 @@ namespace Magitek.Logic
                     }
                 }
 
-                if (currentGambitExecutionStatus)
-                {
-                    GambitQueue = new Queue<Gambit>(StaticGambitQueue);
-                    return true;
-                }
-
-                await Coroutine.Yield();
+                GambitQueue = new Queue<Gambit>(StaticGambitQueue);
+                return true;
             }
 
             return false;
@@ -173,7 +164,7 @@ namespace Magitek.Logic
                             ForbiddenGambits.Remove(gambit.Key);
                     }
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
                     // Ignore that shit
                 }
@@ -232,7 +223,7 @@ namespace Magitek.Logic
                             ForbiddenGambits.Remove(gambit.Key);
                     }
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
                     // Ignore that shit
                 }

--- a/Magitek/Logic/Gunbreaker/Aoe.cs
+++ b/Magitek/Logic/Gunbreaker/Aoe.cs
@@ -44,9 +44,8 @@ namespace Magitek.Logic.Gunbreaker
 
             if (Combat.Enemies.Count(r => r.Distance(Core.Me) <= 5 + r.CombatReach) == 1 && Spells.SonicBreak.Cooldown.TotalMilliseconds > 1)
                 return await Spells.BowShock.Cast(Core.Me);
-            else
-                return await Spells.BowShock.Cast(Core.Me);
-            return false;
+
+            return await Spells.BowShock.Cast(Core.Me);
         }
 
         public static async Task<bool> FatedCircle()

--- a/Magitek/Logic/Machinist/Cooldowns.cs
+++ b/Magitek/Logic/Machinist/Cooldowns.cs
@@ -25,6 +25,9 @@ namespace Magitek.Logic.Machinist
             if (!MachinistGlobals.IsInWeaveingWindow)
                 return false;
 
+            if (ActionResourceManager.Machinist.OverheatRemaining > TimeSpan.Zero)
+                return false;
+
             if (ActionResourceManager.Machinist.Heat > 45 && Spells.Wildfire.Cooldown.TotalMilliseconds <= 6000)
                 return false;
 

--- a/Magitek/Logic/Scholar/Buff.cs
+++ b/Magitek/Logic/Scholar/Buff.cs
@@ -75,12 +75,12 @@ namespace Magitek.Logic.Scholar
             if (Spells.EmergencyTactics.Cooldown != TimeSpan.Zero)
                 return false;
 
-            if (await Spells.EmergencyTactics.CastAura(Core.Me, Auras.EmergencyTactics))
-            {
-                return await Coroutine.Wait(15000, () => Core.Me.HasAura(Auras.EmergencyTactics, true, 10000));
-            }
-
-            return false;
+            return await Spells.EmergencyTactics.CastAura(Core.Me, Auras.EmergencyTactics);
+            //if (await Spells.EmergencyTactics.CastAura(Core.Me, Auras.EmergencyTactics))
+            //{
+            //    return await Coroutine.Wait(15000, () => Core.Me.HasAura(Auras.EmergencyTactics, true, 10000));
+            //}
+            //return false;
         }
 
         public static async Task<bool> Aetherflow()
@@ -165,7 +165,7 @@ namespace Magitek.Logic.Scholar
 
                     var chainStrategemsTarget = GameObjectManager.Attackers.FirstOrDefault(r => r.Distance(Core.Me) <= 25 && r.HasTarget && r.TargetGameObject.IsTank());
 
-                    if (chainStrategemsTarget == null)
+                    if (chainStrategemsTarget == null || !chainStrategemsTarget.ThoroughCanAttack())
                         return false;
                     if (Casting.LastSpell != Spells.Biolysis || Casting.LastSpell != Spells.ArtOfWar || Casting.LastSpell != Spells.Adloquium || Casting.LastSpell != Spells.Succor)
                         if (await Spells.Ruin2.Cast(Core.Me.CurrentTarget))
@@ -178,7 +178,7 @@ namespace Magitek.Logic.Scholar
 
                     var chainStrategemsBossTarget = GameObjectManager.Attackers.FirstOrDefault(r => r.Distance(Core.Me) <= 25 && r.IsBoss() && r.HasTarget && r.TargetGameObject.IsTank());
 
-                    if (chainStrategemsBossTarget == null)
+                    if (chainStrategemsBossTarget == null || !chainStrategemsBossTarget.ThoroughCanAttack())
                         return false;
                     if (Casting.LastSpell != Spells.Biolysis || Casting.LastSpell != Spells.ArtOfWar || Casting.LastSpell != Spells.Adloquium || Casting.LastSpell != Spells.Succor)
                         if (await Spells.Ruin2.Cast(Core.Me.CurrentTarget))

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -449,7 +449,7 @@ namespace Magitek.Logic.Scholar
                 if (ScholarSettings.Instance.SwiftcastRes && Spells.Swiftcast.Cooldown == TimeSpan.Zero) {
                     if (await Buff.Swiftcast()) {
                         while (Core.Me.HasAura(Auras.Swiftcast)) {
-                            if (await Spells.Resurrection.Cast(deadTarget))
+                            if (await Spells.Resurrection.CastAura(deadTarget, Auras.Raise))
                                 return true;
                             await Coroutine.Yield();
                         }
@@ -458,8 +458,11 @@ namespace Magitek.Logic.Scholar
             }
 
             if (Globals.PartyInCombat && ScholarSettings.Instance.SlowcastRes || !Globals.PartyInCombat && ScholarSettings.Instance.ResOutOfCombat) {
-                if (Casting.LastSpell == Spells.Resurrection && Casting.LastSpellTarget == deadTarget && Casting.LastSpellSucceeded)
-                    return false;
+                //delay casting raise on the same target in case they are already in the resurrect animation and the buff is gone for some reason
+                //but this shouldn't be needed outside of Trust NPCs
+                //if(Casting.SpellCastHistory.Take(5).Any(s => s.Spell == Spells.Resurrection && s.SpellTarget == deadTarget))
+                //    return false;
+                
                 return await Spells.Resurrection.CastAura(deadTarget, Auras.Raise);
             }
             

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -105,7 +105,7 @@ namespace Magitek.Logic.Scholar
                     if (tankAdloTarget == null)
                         return false;
 
-                    if (tankAdloTarget.CurrentHealthPercent <= ScholarSettings.Instance.EmergencyTacticsAdloquiumHealthPercent) {
+                    if (ScholarSettings.Instance.EmergencyTactics && ScholarSettings.Instance.EmergencyTacticsAdloquium && tankAdloTarget.CurrentHealthPercent <= ScholarSettings.Instance.EmergencyTacticsAdloquiumHealthPercent) {
                         await Buff.EmergencyTactics();
                     }
 
@@ -119,7 +119,7 @@ namespace Magitek.Logic.Scholar
                 if (adloTarget == null)
                     return false;
 
-                if (adloTarget.CurrentHealthPercent <= ScholarSettings.Instance.EmergencyTacticsAdloquiumHealthPercent) {
+                if (ScholarSettings.Instance.EmergencyTactics && ScholarSettings.Instance.EmergencyTacticsAdloquium && adloTarget.CurrentHealthPercent <= ScholarSettings.Instance.EmergencyTacticsAdloquiumHealthPercent) {
                     await Buff.EmergencyTactics();
                 }
 
@@ -153,7 +153,7 @@ namespace Magitek.Logic.Scholar
             if (Core.Me.CurrentHealthPercent > ScholarSettings.Instance.AdloquiumHpPercent || Core.Me.HasAura(Auras.Galvanize))
                 return false;
 
-            if (Core.Me.CurrentHealthPercent <= ScholarSettings.Instance.EmergencyTacticsAdloquiumHealthPercent) {
+            if (ScholarSettings.Instance.EmergencyTactics && ScholarSettings.Instance.EmergencyTacticsAdloquium && Core.Me.CurrentHealthPercent <= ScholarSettings.Instance.EmergencyTacticsAdloquiumHealthPercent) {
                 await Buff.EmergencyTactics();
             }
             
@@ -198,7 +198,7 @@ namespace Magitek.Logic.Scholar
             if (!needSuccor)
                 return false;
 
-            if (ScholarSettings.Instance.EmergencyTacticsSuccor) {
+            if (ScholarSettings.Instance.EmergencyTactics && ScholarSettings.Instance.EmergencyTacticsSuccor) {
                 if (Group.CastableAlliesWithin15.Count(r => r.CurrentHealthPercent <= ScholarSettings.Instance.EmergencyTacticsSuccorHealthPercent) >= ScholarSettings.Instance.SuccorNeedHealing) {
                     await Buff.EmergencyTactics();
                 }

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -121,7 +121,7 @@ namespace Magitek.Logic.Scholar
                 if (adloTarget == null)
                     return false;
 
-                if (adloTarget.CurrentHealthPercent < ScholarSettings.Instance.EmergencyTacticsAdloquiumHealthPercent) {
+                if (adloTarget.CurrentHealthPercent <= ScholarSettings.Instance.EmergencyTacticsAdloquiumHealthPercent) {
                     await Buff.EmergencyTactics();
                 }
 
@@ -155,7 +155,7 @@ namespace Magitek.Logic.Scholar
             if (Core.Me.CurrentHealthPercent > ScholarSettings.Instance.AdloquiumHpPercent || Core.Me.HasAura(Auras.Galvanize))
                 return false;
 
-            if (Core.Me.CurrentHealthPercent < ScholarSettings.Instance.EmergencyTacticsAdloquiumHealthPercent) {
+            if (Core.Me.CurrentHealthPercent <= ScholarSettings.Instance.EmergencyTacticsAdloquiumHealthPercent) {
                 await Buff.EmergencyTactics();
             }
             

--- a/Magitek/Logic/Warrior/Buff.cs
+++ b/Magitek/Logic/Warrior/Buff.cs
@@ -88,7 +88,6 @@ namespace Magitek.Logic.Warrior
 
         internal static async Task<bool> Infuriate()
         {
-            int useInfuriate = 1;
             if (!WarriorSettings.Instance.UseInfuriate)
                 return false;
 

--- a/Magitek/Models/Samurai/SamuraiSettings.cs
+++ b/Magitek/Models/Samurai/SamuraiSettings.cs
@@ -23,7 +23,7 @@ namespace Magitek.Models.Samurai
 
         [Setting]
         [DefaultValue(50.0f)]
-        public float SecondWindHealthPercent { get; set; }
+        public new float SecondWindHealthPercent { get; set; }
 
         [Setting]
         [DefaultValue(true)]

--- a/Magitek/Models/Scholar/ScholarSettings.cs
+++ b/Magitek/Models/Scholar/ScholarSettings.cs
@@ -65,9 +65,12 @@ namespace Magitek.Models.Scholar
         [DefaultValue(true)]
         public bool InterruptHealing { get; set; }
 
+        [Setting] 
+        [DefaultValue(true)] 
+        public bool SwiftcastRes { get; set; }
+
         [Setting]
         [DefaultValue(true)]
-
         public bool ResOutOfCombat { get; set; }
 
         [Setting]
@@ -93,10 +96,6 @@ namespace Magitek.Models.Scholar
         [Setting]
         [DefaultValue(false)]
         public bool ForceSeraph { get; set; }
-
-        [Setting]
-        [DefaultValue(true)]
-        public bool SwiftcastRes { get; set; }
 
         [Setting]
         [DefaultValue(true)]

--- a/Magitek/Rotations/Scholar.cs
+++ b/Magitek/Rotations/Scholar.cs
@@ -1,4 +1,5 @@
-﻿using ff14bot;
+﻿using System.Linq;
+using ff14bot;
 using ff14bot.Managers;
 using Magitek.Extensions;
 using Magitek.Logic;
@@ -120,7 +121,7 @@ namespace Magitek.Rotations
                 if (await Logic.Scholar.Heal.SacredSoil()) return true;
             }
 
-            if (await Logic.Scholar.Heal.EmergencyTacticsAdlo()) return true;
+            //if (await Logic.Scholar.Heal.EmergencyTacticsAdlo()) return true;
             if (await Logic.Scholar.Heal.Adloquium()) return true;
             if (await Logic.Scholar.Heal.Physick()) return true;
 
@@ -135,6 +136,9 @@ namespace Magitek.Rotations
                     return true;
 
                 if (Core.Me.CurrentManaPercent < ScholarSettings.Instance.MinimumManaPercent)
+                    return true;
+
+                if (Group.CastableAlliesWithin30.Any(c => c?.CurrentHealthPercent < ScholarSettings.Instance.DamageOnlyIfAboveHealthPercent))
                     return true;
             }
 

--- a/Magitek/Rotations/Scholar.cs
+++ b/Magitek/Rotations/Scholar.cs
@@ -121,7 +121,6 @@ namespace Magitek.Rotations
                 if (await Logic.Scholar.Heal.SacredSoil()) return true;
             }
 
-            //if (await Logic.Scholar.Heal.EmergencyTacticsAdlo()) return true;
             if (await Logic.Scholar.Heal.Adloquium()) return true;
             if (await Logic.Scholar.Heal.Physick()) return true;
 

--- a/Magitek/Rotations/Scholar.cs
+++ b/Magitek/Rotations/Scholar.cs
@@ -137,9 +137,6 @@ namespace Magitek.Rotations
 
                 if (Core.Me.CurrentManaPercent < ScholarSettings.Instance.MinimumManaPercent)
                     return true;
-
-                //if (Group.CastableAlliesWithin30.Any(c => c?.CurrentHealthPercent < ScholarSettings.Instance.DamageOnlyIfAboveHealthPercent))
-                //    return true;
             }
 
             return await Combat();
@@ -175,6 +172,9 @@ namespace Magitek.Rotations
                     return true;
 
                 if (Core.Me.CurrentManaPercent < ScholarSettings.Instance.MinimumManaPercent)
+                    return true;
+
+                if (Group.CastableAlliesWithin30.Any(c => c?.CurrentHealthPercent < ScholarSettings.Instance.DamageOnlyIfAboveHealthPercent))
                     return true;
             }
 

--- a/Magitek/Rotations/Scholar.cs
+++ b/Magitek/Rotations/Scholar.cs
@@ -138,8 +138,8 @@ namespace Magitek.Rotations
                 if (Core.Me.CurrentManaPercent < ScholarSettings.Instance.MinimumManaPercent)
                     return true;
 
-                if (Group.CastableAlliesWithin30.Any(c => c?.CurrentHealthPercent < ScholarSettings.Instance.DamageOnlyIfAboveHealthPercent))
-                    return true;
+                //if (Group.CastableAlliesWithin30.Any(c => c?.CurrentHealthPercent < ScholarSettings.Instance.DamageOnlyIfAboveHealthPercent))
+                //    return true;
             }
 
             return await Combat();

--- a/Magitek/Utilities/Routines/Scholar.cs
+++ b/Magitek/Utilities/Routines/Scholar.cs
@@ -89,17 +89,31 @@ namespace Magitek.Utilities.Routines
             if (Casting.CastingSpell == Spells.Succor || Casting.CastingSpell == Spells.Adloquium)
                 return false;
 
-            //if (Core.Me.HasMyAura(Auras.EmergencyTactics) 
-            //    && (Casting.CastingSpell != Spells.Succor || Casting.CastingSpell != Spells.Adloquium)) {
-            //    Logger.Error($@"Stopped Healing: Need to use Emergency Tactics");
-            //    return true;
-            //}
-
             if (ScholarSettings.Instance.InterruptHealing && Casting.DoHealthChecks && Casting.SpellTarget?.CurrentHealthPercent >= ScholarSettings.Instance.InterruptHealingPercent)
             {
                 Logger.Error($@"Stopped Healing: Target's Health Too High");
                 return true;
             }
+
+            if (ScholarSettings.Instance.StopCastingIfBelowHealthPercent && Globals.InParty) {
+                if (Casting.CastingSpell == Spells.Broil ||
+                    Casting.CastingSpell == Spells.Broil2 ||
+                    Casting.CastingSpell == Spells.Broil3 ||
+                    Casting.CastingSpell == Spells.Ruin
+                    ) {
+                    if (Group.CastableAlliesWithin30.Any(c => c?.CurrentHealthPercent < ScholarSettings.Instance.DamageOnlyIfAboveHealthPercent)) {
+                        Logger.Error($@"Stopped Cast: Ally below {ScholarSettings.Instance.DamageOnlyIfAboveHealthPercent}% Health");
+                        return true;
+                    }
+                }
+            }
+
+            //if (ScholarSettings.Instance.SlowcastRes) {
+            //    if (Casting.CastingSpell == Spells.Resurrection && Casting.SpellTarget?.CurrentHealth > 1) {
+            //        Logger.Error($@"Stopped Cast: Target is not Dead");
+            //        return true;
+            //    }
+            //}
 
             /*if (!ScholarSettings.Instance.UseTankBusters || !ScholarSettings.Instance.PrioritizeTankBusters)
                 return false;*/

--- a/Magitek/Utilities/Routines/Scholar.cs
+++ b/Magitek/Utilities/Routines/Scholar.cs
@@ -101,7 +101,7 @@ namespace Magitek.Utilities.Routines
                     Casting.CastingSpell == Spells.Broil3 ||
                     Casting.CastingSpell == Spells.Ruin
                     ) {
-                    if (Group.CastableAlliesWithin30.Any(c => c?.CurrentHealthPercent < ScholarSettings.Instance.DamageOnlyIfAboveHealthPercent)) {
+                    if (Group.CastableAlliesWithin30.Any(c => c?.CurrentHealth > 0 && c.IsAlive && c.CurrentHealthPercent < ScholarSettings.Instance.DamageOnlyIfAboveHealthPercent)) {
                         Logger.Error($@"Stopped Cast: Ally below {ScholarSettings.Instance.DamageOnlyIfAboveHealthPercent}% Health");
                         return true;
                     }

--- a/Magitek/Utilities/Routines/Scholar.cs
+++ b/Magitek/Utilities/Routines/Scholar.cs
@@ -70,7 +70,7 @@ namespace Magitek.Utilities.Routines
                 return !Group.CastableAlliesWithin15.All(r => r.HasAura(Auras.Galvanize));
             }
         }*/
-
+        
         public static bool NeedToInterruptCast()
         {
             /*if (Casting.CastingTankBuster)
@@ -81,19 +81,20 @@ namespace Magitek.Utilities.Routines
                 Logger.Error($@"Stopped Cast: Unit Died");
                 return true;
             }
-
+            
             // Scalebound Extreme Rathalos
             if (Core.Me.HasAura(1495))
                 return false;
 
-            if (Casting.CastingSpell == Spells.Succor)
+            if (Casting.CastingSpell == Spells.Succor || Casting.CastingSpell == Spells.Adloquium)
                 return false;
 
-            if (Core.Me.HasAura(Auras.EmergencyTactics))
-            {
-                Logger.Error($@"Stopped Healing: Need to use Emergency Tactics");
-                return true;
-            }
+            //if (Core.Me.HasMyAura(Auras.EmergencyTactics) 
+            //    && (Casting.CastingSpell != Spells.Succor || Casting.CastingSpell != Spells.Adloquium)) {
+            //    Logger.Error($@"Stopped Healing: Need to use Emergency Tactics");
+            //    return true;
+            //}
+
             if (ScholarSettings.Instance.InterruptHealing && Casting.DoHealthChecks && Casting.SpellTarget?.CurrentHealthPercent >= ScholarSettings.Instance.InterruptHealingPercent)
             {
                 Logger.Error($@"Stopped Healing: Target's Health Too High");

--- a/Magitek/ViewModels/GambitsViewModel.cs
+++ b/Magitek/ViewModels/GambitsViewModel.cs
@@ -479,7 +479,7 @@ namespace Magitek.ViewModels
                 }
 
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 //  
             }

--- a/Magitek/ViewModels/MagitekApi.cs
+++ b/Magitek/ViewModels/MagitekApi.cs
@@ -242,7 +242,7 @@ namespace Magitek.ViewModels
                 {
                     Status = JsonConvert.DeserializeObject<MagitekApiResult>(contributorResponseContent).Description;
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
                     Logger.Error("Couldn't Deserialize Magitek API Result");
                     return;
@@ -258,7 +258,7 @@ namespace Magitek.ViewModels
             {
                 contributor = JsonConvert.DeserializeObject<MagitekContributor>(contributorResponseContent);
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 Logger.Error("Couldn't Deserialize Magitek Contributor Object");
                 return;


### PR DESCRIPTION
- integrated ET into the regular heal rotation rather than making it a separate task
- added the "only deal damage if everyone is above x%" and similar setting into the rotation so it actually does that now
- fixed slow raising on SCH
- added much needed null checks to some SCH spells
- removed some unused variables to reduce warnings when compiling
- AST fix: added a cooldown check to Earthy Star