### PR TITLE
Dancer Flourish Aura Changes

### DIFF
--- a/Magitek/Logic/Dancer/SingleTarget.cs
+++ b/Magitek/Logic/Dancer/SingleTarget.cs
@@ -22,14 +22,14 @@ namespace Magitek.Logic.Dancer
 
         public static async Task<bool> Fountainfall()
         {
-            if (!Core.Me.HasAura(Auras.FlourshingFountain)) return false;
+            if (!Core.Me.HasAura(Auras.FlourshingFlow) && !Core.Me.HasAura(Auras.FlourshingFountain)) return false;
 
             return await Spells.Fountainfall.Cast(Core.Me.CurrentTarget);
         }
 
         public static async Task<bool> ReverseCascade()
         {
-            if (!Core.Me.HasAura(Auras.FlourshingCascade)) return false;
+            if (!Core.Me.HasAura(Auras.FlourishingSymmetry) && !Core.Me.HasAura(Auras.FlourshingFountain)) return false;
 
             return await Spells.ReverseCascade.Cast(Core.Me.CurrentTarget);
         }

--- a/Magitek/Utilities/Auras.cs
+++ b/Magitek/Utilities/Auras.cs
@@ -246,7 +246,12 @@ namespace Magitek.Utilities
             SearingLight = 2703,
             ChainStratagem = 1406,
             EnhancedGibbet = 2588,
-            EnhancedGallows = 2589;
+            EnhancedGallows = 2589,
+
+            FlourishingSymmetry = 2693,
+            FlourshingFlow = 2694,
+            FourfoldFanDance = 2699,
+            FlourishingStarfall = 2700;
 
         private const int
             Invincibility0 = 981,


### PR DESCRIPTION
The Aura needed for Fountain Fall and Reverse Cascade were changed.

 Flourishing Symmetry for Reverse Cascade
 Flourshing Flow for Fountain Fall. 

Also added the aura id's for 4th Fan Dance  and Flourishing Starfall.