### PR TITLE
Grim Reaping won't get stuck under level 90.

### DIFF
--- a/Magitek/Logic/Reaper/Enshroud/AoE.cs
+++ b/Magitek/Logic/Reaper/Enshroud/AoE.cs
@@ -17,7 +17,7 @@ namespace Magitek.Logic.Reaper.Enshroud
             if (!ReaperSettings.Instance.UseGrimReaping || Core.Me.ClassLevel < Spells.GrimReaping.LevelAcquired)
                 return false;
             
-            if (ActionResourceManager.Reaper.LemureShroud < 2) return false;
+            if (ActionResourceManager.Reaper.LemureShroud < 2 && Core.Me.ClassLevel >= Spells.Communio.LevelAcquired) return false;
 
             if (Core.Me.HasAura(Auras.EnhancedVoidReaping) || Core.Me.HasAura(Auras.EnhancedCrossReaping))
             {

--- a/Magitek/Logic/Reaper/Normal/AoE.cs
+++ b/Magitek/Logic/Reaper/Normal/AoE.cs
@@ -49,6 +49,9 @@ namespace Magitek.Logic.Reaper
             if (!Core.Me.CurrentTarget.HasAura(Auras.DeathsDesign, true))
                 return false;
 
+            if (Core.Me.CurrentTarget.EnemiesNearby(5).Count() >= ReaperSettings.Instance.HarvestMoonTargetCount)
+                return false;
+
             return await Spells.HarvestMoon.Cast(Core.Me.CurrentTarget);
         }
 

--- a/Magitek/Logic/Reaper/Normal/AoE.cs
+++ b/Magitek/Logic/Reaper/Normal/AoE.cs
@@ -43,6 +43,12 @@ namespace Magitek.Logic.Reaper
             if (!Core.Me.HasAura(Auras.Soulsow))
                 return false;
 
+            if (Core.Me.HasAura(Auras.SoulReaver))
+                return false;
+
+            if (!Core.Me.CurrentTarget.HasAura(Auras.DeathsDesign, true))
+                return false;
+
             return await Spells.HarvestMoon.Cast(Core.Me.CurrentTarget);
         }
 
@@ -116,8 +122,9 @@ namespace Magitek.Logic.Reaper
                 return false;
             if (!ReaperSettings.Instance.UseGrimSwathe) return false;
             if (Utilities.Routines.Reaper.EnemiesIn8YardCone < ReaperSettings.Instance.GrimSwatheTargetCount) return false;
-            if (Core.Me.HasAura(2587)) return false;
+            if (Core.Me.HasAura(Auras.SoulReaver)) return false;
             if (Spells.Gluttony.Cooldown.Ticks == 0 || (Spells.Gluttony.AdjustedCooldown - Spells.Gluttony.Cooldown <= Spells.Slice.AdjustedCooldown)) return false;
+            if (!Core.Me.CurrentTarget.HasAura(Auras.DeathsDesign, true)) return false;
 
             return await Spells.GrimSwathe.Cast(Core.Me.CurrentTarget);
         }
@@ -132,7 +139,7 @@ namespace Magitek.Logic.Reaper
             if (Core.Me.ClassLevel < Spells.Guillotine.LevelAcquired)
                 return false;
             if (!ReaperSettings.Instance.UseGuillotine) return false;
-            if (!Core.Me.HasAura(2587)) return false;
+            if (!Core.Me.HasAura(Auras.SoulReaver)) return false;
             if (Utilities.Routines.Reaper.EnemiesIn8YardCone < ReaperSettings.Instance.GuillotineTargetCount) return false;
             return await Spells.Guillotine.Cast(Core.Me.CurrentTarget);
         }

--- a/Magitek/Logic/Reaper/Normal/Cooldown.cs
+++ b/Magitek/Logic/Reaper/Normal/Cooldown.cs
@@ -18,8 +18,9 @@ namespace Magitek.Logic.Reaper
             if (Core.Me.ClassLevel < Spells.Gluttony.LevelAcquired)
                 return false;
             if (!ReaperSettings.Instance.UseGluttony) return false;
-            if (Core.Me.HasAura(2587)) return false;
+            if (Core.Me.HasAura(Auras.SoulReaver)) return false;
             if (Spells.Slice.Cooldown > new TimeSpan(Spells.Slice.AdjustedCooldown.Ticks / 2)) return false;
+            if (!Core.Me.CurrentTarget.HasAura(Auras.DeathsDesign, true)) return false;
 
             return await Spells.Gluttony.Cast(Core.Me.CurrentTarget);
         }
@@ -33,6 +34,7 @@ namespace Magitek.Logic.Reaper
                 return false;
             if (!ReaperSettings.Instance.UseEnshroud) return false;
             if (ActionResourceManager.Reaper.ShroudGauge < 50) return false;
+            if (!Core.Me.CurrentTarget.HasAura(Auras.DeathsDesign, true)) return false;
 
             return await Spells.Enshroud.Cast(Core.Me);
         }

--- a/Magitek/Logic/Reaper/Normal/SingleTarget.cs
+++ b/Magitek/Logic/Reaper/Normal/SingleTarget.cs
@@ -19,6 +19,9 @@ namespace Magitek.Logic.Reaper
             if (!ReaperSettings.Instance.UseShadowOfDeath)
                 return false;
 
+            if (Core.Me.HasAura(Auras.SoulReaver))
+                return false;
+
             if (Utilities.Routines.Reaper.EnemiesAroundPlayer5Yards >= ReaperSettings.Instance.WhorlOfDeathTargetCount)
                 return false;
 
@@ -102,7 +105,7 @@ namespace Magitek.Logic.Reaper
 
         public static async Task<bool> GibbetAndGallows()
         {
-            if (!Core.Me.HasAura(2587)) return false;
+            if (!Core.Me.HasAura(Auras.SoulReaver)) return false;
             if (Core.Me.HasAura(Auras.EnhancedGibbet))
             {
                 if (ReaperSettings.Instance.UseGibbet)
@@ -146,7 +149,8 @@ namespace Magitek.Logic.Reaper
                 return false;
             if (!ReaperSettings.Instance.UseBloodStalk) return false;
             if (Spells.Gluttony.Cooldown.Ticks == 0 || (Spells.Gluttony.AdjustedCooldown - Spells.Gluttony.Cooldown <= Spells.Slice.AdjustedCooldown)) return false;
-            if (Core.Me.HasAura(2587)) return false;
+            if (Core.Me.HasAura(Auras.SoulReaver)) return false;
+            if (!Core.Me.CurrentTarget.HasAura(Auras.DeathsDesign, true)) return false;
 
             return await Spells.BloodStalk.Cast(Core.Me.CurrentTarget);
         }

--- a/Magitek/Logic/Reaper/Normal/SingleTarget.cs
+++ b/Magitek/Logic/Reaper/Normal/SingleTarget.cs
@@ -157,5 +157,22 @@ namespace Magitek.Logic.Reaper
 
         #endregion
 
+        public static async Task<bool> HarvestMoon()
+        {
+
+            if (!ReaperSettings.Instance.UseHarvestMoon)
+                return false;
+
+            if (!Core.Me.HasAura(Auras.Soulsow))
+                return false;
+
+            if (Core.Me.HasAura(Auras.SoulReaver))
+                return false;
+
+            if (!Core.Me.CurrentTarget.HasAura(Auras.DeathsDesign, true))
+                return false;
+
+            return await Spells.HarvestMoon.Cast(Core.Me.CurrentTarget);
+        }
     }
 }

--- a/Magitek/Models/Reaper/ReaperSettings.cs
+++ b/Magitek/Models/Reaper/ReaperSettings.cs
@@ -163,6 +163,10 @@ namespace Magitek.Models.Reaper
         [DefaultValue(true)]
         public bool UseHarvestMoon { get; set; }
 
+        [Setting]
+        [DefaultValue(3)]
+        public int HarvestMoonTargetCount { get; set; }
+
         #endregion
 
         #region Cooldowns

--- a/Magitek/Rotations/Reaper.cs
+++ b/Magitek/Rotations/Reaper.cs
@@ -142,7 +142,8 @@ namespace Magitek.Rotations
                 if (await AoE.WhorlofDeathIdle()) return true;
                 if (await AoE.SpinningScythe()) return true;
                 if (await SingleTarget.ShadowOfDeathIdle()) return true;
-                return await SingleTarget.Slice();
+                if (await SingleTarget.Slice()) return true;
+                return await SingleTarget.HarvestMoon();
             }
 
             return false;

--- a/Magitek/Rotations/Reaper.cs
+++ b/Magitek/Rotations/Reaper.cs
@@ -127,9 +127,9 @@ namespace Magitek.Rotations
                     if (await Utility.TrueNorth()) return true;
                 }
 
-                if (await Utility.Soulsow()) return true;
                 if (await AoE.WhorlofDeath()) return true;
                 if (await SingleTarget.ShadowOfDeath()) return true;
+                if (await AoE.HarvestMoon()) return true;
                 if (await AoE.PlentifulHarvest()) return true;
                 if (await AoE.Guillotine()) return true;
                 if (await SingleTarget.GibbetAndGallows()) return true;
@@ -139,11 +139,10 @@ namespace Magitek.Rotations
                 if (await AoE.NightmareScythe()) return true;
                 if (await SingleTarget.InfernalSlice()) return true;
                 if (await SingleTarget.WaxingSlice()) return true;
-                if (await AoE.SpinningScythe()) return true;
                 if (await AoE.WhorlofDeathIdle()) return true;
+                if (await AoE.SpinningScythe()) return true;
                 if (await SingleTarget.ShadowOfDeathIdle()) return true;
-                if (await SingleTarget.Slice()) return true;
-                return await AoE.HarvestMoon();
+                return await SingleTarget.Slice();
             }
 
             return false;

--- a/Magitek/Views/UserControls/Reaper/AoE.xaml
+++ b/Magitek/Views/UserControls/Reaper/AoE.xaml
@@ -28,6 +28,15 @@
 
         <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
             <StackPanel Margin="5">
+                <StackPanel Orientation="Horizontal">
+                    <CheckBox Margin="5" Content=" Enable Harvest Moon, Target Count greater or equal to " IsChecked="{Binding ReaperSettings.UseHarvestMoon, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <controls:Numeric MaxValue="100" MinValue="0" Increment="1" Value="{Binding ReaperSettings.HarvestMoonTargetCount, Mode=TwoWay}"/>
+                </StackPanel>
+            </StackPanel>
+        </controls:SettingsBlock>
+
+        <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
+            <StackPanel Margin="5">
                 <StackPanel Orientation="Horizontal" >
                     <CheckBox Margin="5" Content=" Enable Spinning Scythe, Target Count greater or equal to " IsChecked="{Binding ReaperSettings.UseSpinningScythe, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                     <controls:Numeric MaxValue="100" MinValue="0" Increment="1" Value="{Binding ReaperSettings.SpinningScytheTargetCount, Mode=TwoWay}"/>
@@ -73,7 +82,7 @@
                     <controls:Numeric MaxValue="100" MinValue="0" Increment="1" Value="{Binding ReaperSettings.LemuresScytheTargetCount, Mode=TwoWay}"/>
                 </StackPanel>
                 <StackPanel Orientation="Horizontal">
-                    <CheckBox Margin="5" Content=" Enable Communio, Target Count greater or equal to " IsChecked="{Binding ReaperSettings.UseCommunio, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <CheckBox Margin="5" Content=" Enable Communio " IsChecked="{Binding ReaperSettings.UseCommunio, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                 </StackPanel>
             </StackPanel>
         </controls:SettingsBlock>


### PR DESCRIPTION
Check if targets are buffed with Deaths Design before casting certain spells.
Now uses HarvestMoon as soon as Deaths Design is applied.