### PR TITLE
Invincibility

### DIFF
--- a/Magitek/Rotations/Astrologian.cs
+++ b/Magitek/Rotations/Astrologian.cs
@@ -163,6 +163,9 @@ namespace Magitek.Rotations
                 || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
 
+            if (Core.Me.CurrentTarget.HasAnyAura(Auras.Invincibility))
+                return false;
+
             if (Globals.OnPvpMap)
             {
                 if (await Pvp.Disable()) return true; //Damage

--- a/Magitek/Rotations/Bard.cs
+++ b/Magitek/Rotations/Bard.cs
@@ -86,6 +86,9 @@ namespace Magitek.Rotations
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
 
+            if (Core.Me.CurrentTarget.HasAnyAura(Auras.Invincibility))
+                return false;
+
             if (await CustomOpenerLogic.Opener()) return true;
 
             if (BotManager.Current.IsAutonomous)

--- a/Magitek/Rotations/Dancer.cs
+++ b/Magitek/Rotations/Dancer.cs
@@ -92,6 +92,9 @@ namespace Magitek.Rotations
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
 
+            if (Core.Me.CurrentTarget.HasAnyAura(Auras.Invincibility))
+                return false;
+
             if (await CustomOpenerLogic.Opener()) return true;
             if (await GambitLogic.Gambit()) return true;
 

--- a/Magitek/Rotations/DarkKnight.cs
+++ b/Magitek/Rotations/DarkKnight.cs
@@ -62,6 +62,9 @@ namespace Magitek.Rotations
 
             if (await CustomOpenerLogic.Opener()) return true;
 
+            if (Core.Me.CurrentTarget.HasAnyAura(Auras.Invincibility))
+                return false;
+
             //if (await Defensive.ExecuteTankBusters()) return true;
 
             if (BotManager.Current.IsAutonomous)

--- a/Magitek/Rotations/Dragoon.cs
+++ b/Magitek/Rotations/Dragoon.cs
@@ -72,6 +72,9 @@ namespace Magitek.Rotations
             if (!Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
 
+            if (Core.Me.CurrentTarget.HasAnyAura(Auras.Invincibility))
+                return false;
+
             if (await CustomOpenerLogic.Opener()) 
                 return true;
 

--- a/Magitek/Rotations/Machinist.cs
+++ b/Magitek/Rotations/Machinist.cs
@@ -75,6 +75,9 @@ namespace Magitek.Rotations
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
 
+            if (Core.Me.CurrentTarget.HasAnyAura(Auras.Invincibility))
+                return false;
+
             if (await CustomOpenerLogic.Opener()) return true;
 
             if (MachinistSettings.Instance.UseFlamethrower && Core.Me.HasAura(Auras.Flamethrower))

--- a/Magitek/Rotations/Monk.cs
+++ b/Magitek/Rotations/Monk.cs
@@ -82,6 +82,9 @@ namespace Magitek.Rotations
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
 
+            if (Core.Me.CurrentTarget.HasAnyAura(Auras.Invincibility))
+                return false;
+
             if (await CustomOpenerLogic.Opener()) return true;
 
 

--- a/Magitek/Rotations/Ninja.cs
+++ b/Magitek/Rotations/Ninja.cs
@@ -85,6 +85,9 @@ namespace Magitek.Rotations
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
 
+            if (Core.Me.CurrentTarget.HasAnyAura(Auras.Invincibility))
+                return false;
+
             if (await CustomOpenerLogic.Opener()) return true;
 
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())

--- a/Magitek/Rotations/Paladin.cs
+++ b/Magitek/Rotations/Paladin.cs
@@ -76,6 +76,9 @@ namespace Magitek.Rotations
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
 
+            if (Core.Me.CurrentTarget.HasAnyAura(Auras.Invincibility))
+                return false;
+
             if (await CustomOpenerLogic.Opener()) return true;
 
             if (!Core.Me.HasAura(Auras.PassageOfArms))

--- a/Magitek/Rotations/Reaper.cs
+++ b/Magitek/Rotations/Reaper.cs
@@ -95,6 +95,9 @@ namespace Magitek.Rotations
                 return false;
             }
 
+            if (Core.Me.CurrentTarget.HasAnyAura(Auras.Invincibility))
+                return false;
+
             if (await CustomOpenerLogic.Opener()) return true;
 
             if (BotManager.Current.IsAutonomous)

--- a/Magitek/Rotations/RedMage.cs
+++ b/Magitek/Rotations/RedMage.cs
@@ -72,6 +72,9 @@ namespace Magitek.Rotations
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
 
+            if (Core.Me.CurrentTarget.HasAnyAura(Auras.Invincibility))
+                return false;
+
             if (await CustomOpenerLogic.Opener()) return true;
 
             if (BotManager.Current.IsAutonomous)

--- a/Magitek/Rotations/Sage.cs
+++ b/Magitek/Rotations/Sage.cs
@@ -155,6 +155,9 @@ namespace Magitek.Rotations
                 || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
 
+            if (Core.Me.CurrentTarget.HasAnyAura(Auras.Invincibility))
+                return false;
+
             if (Globals.OnPvpMap)
             {
                 return false;

--- a/Magitek/Rotations/Scholar.cs
+++ b/Magitek/Rotations/Scholar.cs
@@ -192,6 +192,9 @@ namespace Magitek.Rotations
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
 
+            if (Core.Me.CurrentTarget.HasAnyAura(Auras.Invincibility))
+                return false;
+
             if (await SingleTarget.Bio()) return true;
             if (await SingleTarget.BioMultipleTargets()) return true;
             if (await SingleTarget.Ruin2()) return true;

--- a/Magitek/Rotations/Warrior.cs
+++ b/Magitek/Rotations/Warrior.cs
@@ -64,6 +64,9 @@ namespace Magitek.Rotations
                 Movement.NavigateToUnitLos(Core.Me.CurrentTarget, 3 + Core.Me.CurrentTarget.CombatReach);
             }
 
+            if (Core.Me.CurrentTarget.HasAnyAura(Auras.Invincibility))
+                return false;
+
             //Utility
             if (await Tank.Interrupt(WarriorSettings.Instance)) return true;
             if (await Buff.Defiance()) return true;

--- a/Magitek/Rotations/WhiteMage.cs
+++ b/Magitek/Rotations/WhiteMage.cs
@@ -172,6 +172,9 @@ namespace Magitek.Rotations
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
 
+            if (Core.Me.CurrentTarget.HasAnyAura(Auras.Invincibility))
+                return false;
+
             if (await SingleTarget.Dots()) return true;
             if (await SingleTarget.AfflatusMisery()) return true;
             return await SingleTarget.Stone();


### PR DESCRIPTION
Adding invincibility checks to all combat CRs.

I don't see any functional reason why you would want to hit something that is invulnerable.

Some thoughts:

pro-hitting while invulnerable
precasting while something is about to become vulnerable -- (potentially?) (PLD, healers, casters)
RDM proc-ing dualcast (maybe)

con-hitting while invulnerable
DoTs? -- you can't apply a DoT while something in invulnerable.
you might use a ogcd which did no damage.
you don't get gauge if you do no damage. (RDM, DNC, MCH)
