### PR TITLE
Attack while moving if the spell has no cast time or we have swiftcas…

### DIFF
--- a/Magitek/Extensions/SpellDataExtensions.cs
+++ b/Magitek/Extensions/SpellDataExtensions.cs
@@ -81,7 +81,7 @@ namespace Magitek.Extensions
             // If we're using an autonomous bot base and we're running out of avoidance then don't cast
             if (BotManager.Current.IsAutonomous)
             {
-                if (AvoidanceManager.IsRunningOutOfAvoid)
+                if (AvoidanceManager.IsRunningOutOfAvoid && !(Core.Me.HasAura(Auras.Swiftcast) || spell.AdjustedCastTime <= TimeSpan.Zero))
                     return false;
             }
 


### PR DESCRIPTION
…t up

For jobs that have instant cast spells, you should attack while moving if you have a GCD available.

I held back on pushing this earlier because tank ranged attacks broke combos, but they don't break combos anymore. 

This change works with orderbot.

PLD - shield lob doesn't break combos (also holy spirit during req doesn't get cast if you are moving without this change)
WAR - same
DRK - same
GNB - same

WHM - you should dot or solace while moving
SCH - you should ruin2 while moving
AST - lightspeed spells won't get cast without this change
SGE - ?? but i think eukrasia spells should be cast, but not tested

MNK - n/a
DRG - throw a spear, doesn't break combos anymore
NIN - throw a dagger, doesn't break combos
SAM - I think enpi is a dps loss, but not sure here. in theory I could add a check on enpi if meikyo shisui is up... thinking...
RPR - ?? untested

BRD - should always hit a gcd, doesn't shoot if moving
MCH - same problem
DNC - same problem

BLM - triplecast needs this
SMN - new rotation, but i think it's same problem. i think this might break SMN but I think it needs a rework anyway
RDM - should cast dualcast/swiftcast spells if you are moving during your dualcast windows or in your magic burst phase.