### PR TITLE
Readding shadow fang

### DIFF
--- a/Magitek/Logic/Ninja/Ninjutsu.cs
+++ b/Magitek/Logic/Ninja/Ninjutsu.cs
@@ -352,6 +352,9 @@ namespace Magitek.Logic.Ninja
             if (Spells.TrickAttack.Cooldown.TotalMilliseconds < 45000 && !Core.Me.CurrentTarget.HasAura(Auras.VulnerabilityTrickAttack))
                 return false;
 
+            if (Spells.ShadowFang.Cooldown.TotalMilliseconds < 5000)
+                return false;
+
             if (Spells.SpinningEdge.Cooldown.TotalMilliseconds < 1200)
                 return false;
 

--- a/Magitek/Logic/Ninja/SingleTarget.cs
+++ b/Magitek/Logic/Ninja/SingleTarget.cs
@@ -54,6 +54,17 @@ namespace Magitek.Logic.Ninja
             return false;
         }
 
+        public static async Task<bool> ShadowFang()
+        {
+            if (!NinjaSettings.Instance.UseShadowFang)
+                return false;
+
+            if (Spells.TrickAttack.Cooldown.TotalMilliseconds < 45000)
+                return false;
+
+            return await Spells.ShadowFang.Cast(Core.Me.CurrentTarget);
+        }
+
         public static async Task<bool> Assassinate()
         {
             if (!NinjaSettings.Instance.UseAssassinate)

--- a/Magitek/Rotations/Ninja.cs
+++ b/Magitek/Rotations/Ninja.cs
@@ -150,7 +150,6 @@ namespace Magitek.Rotations
 
                 if (await PhysicalDps.SecondWind(NinjaSettings.Instance)) return true;
 
-                //if (await PhysicalDps.SecondWind(NinjaSettings.Instance)) return true;
                 if (await SingleTarget.TrickAttack()) return true;
                 if (await Ninjutsu.TenChiJin()) return true;
                 if (await Buff.Meisui()) return true;
@@ -163,6 +162,7 @@ namespace Magitek.Rotations
                 if (await SingleTarget.Mug()) return true;
                 if (await Buff.Kassatsu()) return true;
                 if (await SingleTarget.DreamWithinADream()) return true;
+                if (await SingleTarget.ShadowFang()) return true;
             }
 
             //Ninjutsu

--- a/Magitek/Utilities/Spells.cs
+++ b/Magitek/Utilities/Spells.cs
@@ -406,7 +406,7 @@ namespace Magitek.Utilities
         public static readonly SpellData Mug = DataManager.GetSpellData(2248);
         public static readonly SpellData DeathBlossom = DataManager.GetSpellData(2254);
         public static readonly SpellData AeolianEdge = DataManager.GetSpellData(2255);
-        //public static readonly SpellData ShadowFang = DataManager.GetSpellData(2257);
+        public static readonly SpellData ShadowFang = DataManager.GetSpellData(2257);
         public static readonly SpellData TrickAttack = DataManager.GetSpellData(2258);
         public static readonly SpellData Ten = DataManager.GetSpellData(2259);
         public static readonly SpellData Ninjutsu = DataManager.GetSpellData(2260);


### PR DESCRIPTION
Shadow Fang was readded during 5.X and I think nobody plays NIN.

If you're going to apply TrickAttack shortly (assumed), hold off on applying it for this rotation and wait for the next opportunity (3 GCDs).