### PR TITLE
Change logic on nearby enemies as this method is primarily used to de…

### DIFF
--- a/Magitek/Extensions/GameObjectExtensions.cs
+++ b/Magitek/Extensions/GameObjectExtensions.cs
@@ -168,7 +168,7 @@ namespace Magitek.Extensions
 
         public static IEnumerable<BattleCharacter> EnemiesNearby(this GameObject unit, float distance)
         {
-            return Combat.Enemies.Where(r => r.Distance(unit) <= distance);
+            return Combat.Enemies.Where(r => r.Distance(unit) <= distance + Core.Me.CombatReach + unit.CombatReach);
         }
 
         public static IEnumerable<BattleCharacter> EnemiesNearbyOoc(this GameObject unit, float distance)


### PR DESCRIPTION
…termine when to use aoe abilities

Not sure why this is on my local tbh, but I think on second thought it doesn't feel like this is needed... pending more thinking.

I think this was because gravity and other targeted aoe spells weren't being used when they should be, but I haven't tested recently, so this might need another thought.