### PR TITLE
PLD 6.0 Updates - This update provides relatively minor adjustments t…

### DIFF
--- a/Magitek/Logic/Paladin/Aoe.cs
+++ b/Magitek/Logic/Paladin/Aoe.cs
@@ -93,6 +93,11 @@ namespace Magitek.Logic.Paladin
             if (PaladinRoutine.RequiescatStackCount <= 1)
                 return false;
 
+            // In 6.0 PLD will cast Requiescat early because it lasts a long time. We now need
+            // to make sure we don't still have FoF up as well.
+            if (Core.Me.HasAura(Auras.FightOrFight, true))
+                return false;
+
             if (Combat.Enemies.Count(r => r.ValidAttackUnit() && r.Distance(Core.Me) <= 5 + r.CombatReach) < PaladinSettings.Instance.TotalEclipseEnemies)
                 return false;
 
@@ -113,7 +118,10 @@ namespace Magitek.Logic.Paladin
             if (ActionManager.CanCast(Spells.BladeOfValor.Id, Core.Me.CurrentTarget))
                 return await Spells.BladeOfValor.Cast(Core.Me.CurrentTarget);
 
-            if (PaladinRoutine.RequiescatStackCount > 1)
+            // We want to Confit with our last stack, but if the req buff is
+            // about to fall off, and this is our last action, use confit
+            if (PaladinRoutine.RequiescatStackCount > 1
+                && Core.Me.HasAura(Auras.Requiescat, true, 3000))
                 return false;
 
             return await Spells.Confiteor.Cast(Core.Me.CurrentTarget);

--- a/Magitek/Logic/Paladin/SingleTarget.cs
+++ b/Magitek/Logic/Paladin/SingleTarget.cs
@@ -87,26 +87,6 @@ namespace Magitek.Logic.Paladin
             return await Spells.SpiritsWithin.Cast(Core.Me.CurrentTarget);
         }
 
-        public static async Task<bool> Requiescat()
-        {
-            if (!PaladinRoutine.ToggleAndSpellCheck(PaladinSettings.Instance.Requiescat, Spells.Requiescat))
-                return false;
-
-            if (!Core.Me.CurrentTarget.HasAura(Auras.GoringBlade, true, 1900)
-                || Core.Me.HasAuraCharge(Auras.SwordOath))
-                return false;
-
-            if (PaladinSettings.Instance.FoFFirst
-                && Spells.FightorFlight.Cooldown.Seconds < 8
-                && !Core.Me.CurrentTarget.HasAura(Auras.GoringBlade, true, 10000))
-                return false;
-
-            if (Core.Me.HasAura(Auras.FightOrFight, true, 3000))
-                return false;
-
-            return await Spells.Requiescat.Cast(Core.Me.CurrentTarget);
-        }
-
         public static async Task<bool> HolySpirit()
         {
             if (!PaladinRoutine.ToggleAndSpellCheck(PaladinSettings.Instance.HolySpirit, Spells.HolySpirit))
@@ -114,6 +94,20 @@ namespace Magitek.Logic.Paladin
 
             if (PaladinRoutine.RequiescatStackCount <= 1)
                 return false;
+
+            // Before 6.0 PLD would hold Requiestcat until starting the magic combo,
+            // but now it's often put up early during physical combo because it lasts
+            // a long time. It's not sufficient to only check if we have Requiestcat stacks
+            // now, because we could have them but still be in the middle of our phys combo.
+            // We also don't just check if we have FoF because it could be wearing off before
+            // we actually finish the physical combo.
+
+            if (ActionManager.LastSpell == Spells.FastBlade
+                || ActionManager.LastSpell == Spells.RiotBlade
+                || Core.Me.HasAura(Auras.FightOrFight, true, 2000))
+            {
+                return false;
+            }
 
             // TODO:optimization(wildchill)
             // There was a mana check here, but mana is changed in endwalker for paladin magic combo
@@ -148,19 +142,25 @@ namespace Magitek.Logic.Paladin
 
         public static async Task<bool> Atonement()
         {
-            if (Core.Me.ClassLevel < 76 || !Core.Me.HasAura(Auras.SwordOath))
-                return false;
+            // This logic is to accomodate dropping an unbuffed attonement usage,
+            // which puts paladin into a 61 second "standard loop" recommended by
+            // the balance (if you use the 3rd unbuffed attonement it's a 64 second
+            // loop).
+            // TODO:options(wildchill) Maybe add a toggle for 61/64 loop
 
-            //not in FoF Check
-            if (Core.Me.HasAuraCharge(Auras.SwordOath) && !Core.Me.HasAura(Auras.FightOrFight) && Spells.FightorFlight.Cooldown.TotalMilliseconds < 12000)
+            // Don't attonement during combo, including when goring blade was last
+            // because without goring blade check we'd use a left over attonement
+            // that we're trying to drop from the unbuffed segment of the rotation
+            if (ActionManager.LastSpell == Spells.FastBlade
+                || ActionManager.LastSpell == Spells.RiotBlade
+                || ActionManager.LastSpell == Spells.GoringBlade)
+            {
                 return false;
+            }
 
-            //we are in FoF Check
-            if (Core.Me.HasAuraCharge(Auras.SwordOath) && !Core.Me.HasAura(Auras.FightOrFight, true, 7000) && Core.Me.HasAura(Auras.FightOrFight))
-                return false;
-
-            //are we mid combo?
-            if (ActionManager.LastSpell == Spells.FastBlade || ActionManager.LastSpell == Spells.RiotBlade)
+            // If we have a single charge (HasAuraCharge looks for single stack ONLY)
+            // and we're not under FoF then don't use attonement.
+            if (!Core.Me.HasAura(Auras.FightOrFight) && Core.Me.HasAuraCharge(Auras.SwordOath))
                 return false;
 
             return await Spells.Atonement.Cast(Core.Me.CurrentTarget);

--- a/Magitek/Models/Paladin/PaladinSettings.cs
+++ b/Magitek/Models/Paladin/PaladinSettings.cs
@@ -33,7 +33,7 @@ namespace Magitek.Models.Paladin
         public int HealthSetting { get; set; }
 
         [Setting]
-        [DefaultValue(false)]
+        [DefaultValue(true)]
         public bool FoFFastBlade { get; set; }
 
         [Setting]
@@ -67,6 +67,10 @@ namespace Magitek.Models.Paladin
         [Setting]
         [DefaultValue(true)]
         public bool Requiescat { get; set; }
+
+        [Setting]
+        [DefaultValue(1)]
+        public int RequiescatWithFofSecondsRemaining { get; set; }
 
         [Setting]
         [DefaultValue(false)]

--- a/Magitek/Rotations/Paladin.cs
+++ b/Magitek/Rotations/Paladin.cs
@@ -90,7 +90,7 @@ namespace Magitek.Rotations
                     if (await Defensive.Defensives()) return true;
                     if (await Buff.Intervention()) return true;
                     if (await Buff.DivineVeil()) return true;
-                    if (await SingleTarget.Requiescat()) return true;
+                    if (await Buff.Requiescat()) return true;
                     if (await Buff.FightOrFlight()) return true;
                     if (!Utilities.Routines.Paladin.OGCDHold)
                     {

--- a/Magitek/Views/UserControls/Paladin/Buffs.xaml
+++ b/Magitek/Views/UserControls/Paladin/Buffs.xaml
@@ -62,6 +62,34 @@
                     <RowDefinition />
                 </Grid.RowDefinitions>
 
+                <CheckBox Grid.Row="1" Grid.Column="0" Content="Requiescat with" IsChecked="{Binding PaladinSettings.Requiescat, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                <controls:Numeric Grid.Row="1"
+                                  Grid.Column="1"
+                                  Margin="0,3"
+                                  MaxValue="20"
+                                  MinValue="1"
+                                  Value="{Binding PaladinSettings.RequiescatWithFofSecondsRemaining, Mode=TwoWay}" />
+                <TextBlock Grid.Row="1" Grid.Column="2" Style="{DynamicResource TextBlockDefault}" Text=" seconds left on Fight or Flight" />
+                <TextBlock Grid.Row="2" Grid.Column="2" Style="{DynamicResource TextBlockDefault}" Text="(17 recommended for boss fights, 1 for dungeons)" />
+            </Grid>
+        </controls:SettingsBlock>
+
+        <controls:SettingsBlock Background="{DynamicResource ClassSelectorBackground}">
+            <Grid Margin="5">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition />
+                    <RowDefinition />
+                    <RowDefinition />
+                    <RowDefinition />
+                    <RowDefinition />
+                    <RowDefinition />
+                </Grid.RowDefinitions>
+
                 <CheckBox Grid.Row="1" Grid.Column="0" Content="Divine Veil " IsChecked="{Binding PaladinSettings.DivineVeil, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                 <controls:Numeric Grid.Row="1"
                                   Grid.Column="1"
@@ -111,8 +139,8 @@
                     <TextBlock Style="{DynamicResource TextBlockDefault}" Text=" Health Percent" />
                 </StackPanel>
 
-                <CheckBox Content="Only Use Intervention With Sentinel Or Rampart" IsChecked="{Binding PaladinSettings.InterventionOnNearbyPartyMember, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                <CheckBox Margin="0,3,0,0" Content="Always Use Intervention With Sentinel Or Rampart" IsChecked="{Binding PaladinSettings.InterventionOnNearbyPartyMember, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                <CheckBox Content="Only Use Intervention on party member if Sentinel or Rampart is Active" IsChecked="{Binding PaladinSettings.InterventionPartyAlwaysWOCD, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                <CheckBox Margin="0,3,0,0" Content="Use intervention on party member every time Setinel or Rampart is Active" IsChecked="{Binding PaladinSettings.InterventionPartyAlwaysWithCD, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
             </StackPanel>
         </controls:SettingsBlock>
 

--- a/Magitek/Views/UserControls/Paladin/Combat.xaml
+++ b/Magitek/Views/UserControls/Paladin/Combat.xaml
@@ -45,7 +45,15 @@
                 <StackPanel Orientation="Horizontal">
                     <CheckBox Content="Spirits Within" IsChecked="{Binding PaladinSettings.SpiritsWithin, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                 </StackPanel>
+            </StackPanel>
+        </controls:SettingsBlock>
 
+        <controls:SettingsBlock Margin="0,5,0,0" Background="{DynamicResource ClassSelectorBackground}">
+            <StackPanel Margin="5">
+
+                <StackPanel Orientation="Horizontal">
+                    <CheckBox Content="Intervene" IsChecked="{Binding PaladinSettings.Intervene, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                </StackPanel>
             </StackPanel>
         </controls:SettingsBlock>
 
@@ -111,7 +119,6 @@
 
         <controls:SettingsBlock Background="{DynamicResource ClassSelectorBackground}">
             <StackPanel>
-                <CheckBox Margin="5" Content="Requiescat" IsChecked="{Binding PaladinSettings.Requiescat, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                 <CheckBox Margin="5" Content="HolyCircle AoE" IsChecked="{Binding PaladinSettings.HolyCircle, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
             </StackPanel>
         </controls:SettingsBlock>


### PR DESCRIPTION
…o Paladin, fixing some rotational issues that resulted from the job changes in Endwalker. Although the impact of these changes is minor, the code changes were relatively significant, please report any PLD issues in Discord so we can address them!

* Added new settings option for Requiescat allowing for it to be cast earlier than just before the magic combo. The 6.0 PLD standard rotation casts Req during the FoF combo because Req buff lasts for 30s. This early cast can result in an extra usage in some cirumstances. The setting defaults to 1 resulting in pre-6.0 behavior, this default is best for dungeons in my testing. Users seeking more optimal play can adjust this value, 17 seconds places the usage where the balance recommends.
* Moved Requiescat settings from Combat to Buffs menu.
* Fixed UI settings for Intervention usage on party members and clarified the options better.
* Requiestcat will now be cast when we're in an aoe situation even if the target does not have goring debuff, this allows for magic aoe combo to execute (primarily useful for dungeons).
* Added new setting for using Intervene, this was available in the toggles previously but not in settings.
* Fight or Flight will now cast when we're in an aoe situation, this allows for a buffed physical combo to execute (primarily useful for dungeons).
* Fight or Flight now defaults to cast after Fast Blade instead of Riot Blade, users with poor latency can adjust this back to Riot Blade if necessary but this is sub-optimal.
* Confiteor will cast if it is the last gcd under Req buff even if you have more than 1 stack of Req buff.
* Holy Circle will no longer cast when FoF is active.
* Holy Spirit will no longer cast when FoF is active.
* Attonement now "drops" an unbuffed usage to follow the balance 61 second standard rotation. (An option will be added later to not drop this usage and follow the 64-second rotation.)