### PR TITLE
Healer raises

### DIFF
--- a/Magitek/Logic/Astrologian/Heal.cs
+++ b/Magitek/Logic/Astrologian/Heal.cs
@@ -505,17 +505,14 @@ namespace Magitek.Logic.Astrologian
             */
             var deadList = Group.DeadAllies.Where(u => !u.HasAura(Auras.Raise) &&
                                                        u.Distance(Core.Me) <= 30 &&
+                                                       u.IsVisible &&
                                                        u.InLineOfSight() &&
-                                                       u.IsTargetable &&
-                                                       u.IsVisible)
+                                                       u.IsTargetable)
                 .OrderByDescending(r => r.GetResurrectionWeight());
 
             var deadTarget = deadList.FirstOrDefault();
 
             if (deadTarget == null)
-                return false;
-
-            if (!deadTarget.IsTargetable)
                 return false;
 
             if (Core.Me.InCombat || Globals.OnPvpMap)

--- a/Magitek/Logic/Sage/Heal.cs
+++ b/Magitek/Logic/Sage/Heal.cs
@@ -373,15 +373,15 @@ namespace Magitek.Logic.Sage
 
             var deadList = Group.DeadAllies.Where(u => u.CurrentHealth == 0 &&
                                                        !u.HasAura(Auras.Raise) &&
-                                                       u.Distance(Core.Me) <= 30)
+                                                       u.Distance(Core.Me) <= 30 &&
+                                                       u.IsVisible &&
+                                                       u.InLineOfSight() &&
+                                                       u.IsTargetable)
                 .OrderByDescending(r => r.GetResurrectionWeight());
 
             var deadTarget = deadList.FirstOrDefault();
 
             if (deadTarget == null)
-                return false;
-
-            if (!deadTarget.IsVisible || !deadTarget.IsTargetable)
                 return false;
 
             if (Globals.PartyInCombat)

--- a/Magitek/Logic/Scholar/Buff.cs
+++ b/Magitek/Logic/Scholar/Buff.cs
@@ -146,16 +146,16 @@ namespace Magitek.Logic.Scholar
             if (Core.Me.HasAetherflow())
                 return false;
 
-            if (Spells.Aetherflow.Cooldown.TotalMilliseconds < 1500)
-                return await Spells.Aetherflow.Cast(Core.Me);
-
-            if (Core.Me.Pet != null && Spells.Dissipation.Cooldown.TotalMilliseconds < 1500 && Casting.LastSpell == Spells.Aetherflow == false)
-                return await Spells.Dissipation.Cast(Core.Me);
+            if (Spells.Aetherflow.Cooldown.TotalMilliseconds > 1500)
+            {
+                Logger.Error("Aetherflow on cooldown");
+                return false;
+            }
 
             //if (Casting.LastSpell != Spells.Biolysis || Casting.LastSpell != Spells.ArtOfWar || Casting.LastSpell != Spells.Adloquium || Casting.LastSpell != Spells.Succor)
             //    if (await Spells.Ruin2.Cast(Core.Me.CurrentTarget))
             //        return true;
-            return false;
+            return await Spells.Aetherflow.Cast(Core.Me);
         }
 
         public static async Task<bool> DeploymentTactics()
@@ -169,8 +169,8 @@ namespace Magitek.Logic.Scholar
                 return false;
             // Find someone who has the right amount of allies around them based on the users settings
             var deploymentTacticsTarget = Group.CastableAlliesWithin30.FirstOrDefault(r =>
-                r.HasAura(Auras.Galvanize, true)
-                && r.HasAura(Auras.Catalyze, true)
+                r.HasAura(Auras.Galvanize)
+                && r.HasAura(Auras.Catalyze)
                 && Group.CastableAlliesWithin30.Count(x => x.Distance(r) <= 15 + x.CombatReach) >= ScholarSettings.Instance.DeploymentTacticsAllyInRange);
 
             if (deploymentTacticsTarget == null)
@@ -224,7 +224,7 @@ namespace Magitek.Logic.Scholar
                     if (!Globals.InParty)
                         return await Spells.ChainStrategem.Cast(Core.Me.CurrentTarget);
 
-                    var chainStrategemsTarget = GameObjectManager.Attackers.FirstOrDefault(r => r.Distance(Core.Me) <= 25 && r.HasAura(Auras.ChainStratagem) == false && r.HasTarget && r.TargetGameObject.IsTank());
+                    var chainStrategemsTarget = GameObjectManager.Attackers.FirstOrDefault(r => r.Distance(Core.Me) <= 25 && r.HasTarget && r.TargetGameObject.IsTank());
 
                     if (chainStrategemsTarget == null || !chainStrategemsTarget.ThoroughCanAttack())
                         return false;
@@ -237,7 +237,7 @@ namespace Magitek.Logic.Scholar
                     if (!Globals.InParty && Core.Me.CurrentTarget.IsBoss())
                         return await Spells.ChainStrategem.Cast(Core.Me.CurrentTarget);
 
-                    var chainStrategemsBossTarget = GameObjectManager.Attackers.FirstOrDefault(r => r.Distance(Core.Me) <= 25 && r.IsBoss() && r.HasAura(Auras.ChainStratagem) == false && r.HasTarget && r.TargetGameObject.IsTank());
+                    var chainStrategemsBossTarget = GameObjectManager.Attackers.FirstOrDefault(r => r.Distance(Core.Me) <= 25 && r.IsBoss() && r.HasTarget && r.TargetGameObject.IsTank());
 
                     if (chainStrategemsBossTarget == null || !chainStrategemsBossTarget.ThoroughCanAttack())
                         return false;

--- a/Magitek/Logic/Scholar/Buff.cs
+++ b/Magitek/Logic/Scholar/Buff.cs
@@ -146,16 +146,16 @@ namespace Magitek.Logic.Scholar
             if (Core.Me.HasAetherflow())
                 return false;
 
-            if (Spells.Aetherflow.Cooldown.TotalMilliseconds > 1500)
-            {
-                Logger.Error("Aetherflow on cooldown");
-                return false;
-            }
+            if (Spells.Aetherflow.Cooldown.TotalMilliseconds < 1500)
+                return await Spells.Aetherflow.Cast(Core.Me);
+
+            if (Core.Me.Pet != null && Spells.Dissipation.Cooldown.TotalMilliseconds < 1500 && Casting.LastSpell == Spells.Aetherflow == false)
+                return await Spells.Dissipation.Cast(Core.Me);
 
             //if (Casting.LastSpell != Spells.Biolysis || Casting.LastSpell != Spells.ArtOfWar || Casting.LastSpell != Spells.Adloquium || Casting.LastSpell != Spells.Succor)
             //    if (await Spells.Ruin2.Cast(Core.Me.CurrentTarget))
             //        return true;
-            return await Spells.Aetherflow.Cast(Core.Me);
+            return false;
         }
 
         public static async Task<bool> DeploymentTactics()
@@ -169,8 +169,8 @@ namespace Magitek.Logic.Scholar
                 return false;
             // Find someone who has the right amount of allies around them based on the users settings
             var deploymentTacticsTarget = Group.CastableAlliesWithin30.FirstOrDefault(r =>
-                r.HasAura(Auras.Galvanize)
-                && r.HasAura(Auras.Catalyze)
+                r.HasAura(Auras.Galvanize, true)
+                && r.HasAura(Auras.Catalyze, true)
                 && Group.CastableAlliesWithin30.Count(x => x.Distance(r) <= 15 + x.CombatReach) >= ScholarSettings.Instance.DeploymentTacticsAllyInRange);
 
             if (deploymentTacticsTarget == null)
@@ -224,7 +224,7 @@ namespace Magitek.Logic.Scholar
                     if (!Globals.InParty)
                         return await Spells.ChainStrategem.Cast(Core.Me.CurrentTarget);
 
-                    var chainStrategemsTarget = GameObjectManager.Attackers.FirstOrDefault(r => r.Distance(Core.Me) <= 25 && r.HasTarget && r.TargetGameObject.IsTank());
+                    var chainStrategemsTarget = GameObjectManager.Attackers.FirstOrDefault(r => r.Distance(Core.Me) <= 25 && r.HasAura(Auras.ChainStratagem) == false && r.HasTarget && r.TargetGameObject.IsTank());
 
                     if (chainStrategemsTarget == null || !chainStrategemsTarget.ThoroughCanAttack())
                         return false;
@@ -237,7 +237,7 @@ namespace Magitek.Logic.Scholar
                     if (!Globals.InParty && Core.Me.CurrentTarget.IsBoss())
                         return await Spells.ChainStrategem.Cast(Core.Me.CurrentTarget);
 
-                    var chainStrategemsBossTarget = GameObjectManager.Attackers.FirstOrDefault(r => r.Distance(Core.Me) <= 25 && r.IsBoss() && r.HasTarget && r.TargetGameObject.IsTank());
+                    var chainStrategemsBossTarget = GameObjectManager.Attackers.FirstOrDefault(r => r.Distance(Core.Me) <= 25 && r.IsBoss() && r.HasAura(Auras.ChainStratagem) == false && r.HasTarget && r.TargetGameObject.IsTank());
 
                     if (chainStrategemsBossTarget == null || !chainStrategemsBossTarget.ThoroughCanAttack())
                         return false;

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -501,15 +501,15 @@ namespace Magitek.Logic.Scholar
 
             var deadList = Group.DeadAllies.Where(u => u.CurrentHealth == 0 &&
                                                        !u.HasAura(Auras.Raise) &&
-                                                       u.Distance(Core.Me) <= 30)
+                                                       u.Distance(Core.Me) <= 30 &&
+                                                       u.IsVisible &&
+                                                       u.InLineOfSight() &&
+                                                       u.IsTargetable)
                 .OrderByDescending(r => r.GetResurrectionWeight());
 
             var deadTarget = deadList.FirstOrDefault();
 
             if (deadTarget == null)
-                return false;
-
-            if (!deadTarget.IsVisible || !deadTarget.IsTargetable)
                 return false;
 
             if (Globals.PartyInCombat)

--- a/Magitek/Logic/WhiteMage/Heal.cs
+++ b/Magitek/Logic/WhiteMage/Heal.cs
@@ -450,6 +450,7 @@ namespace Magitek.Logic.WhiteMage
 
             var deadList = Group.DeadAllies.Where(u => !u.HasAura(Auras.Raise) &&
                                                        u.Distance(Core.Me) <= 30 &&
+                                                       u.IsVisible &&
                                                        u.InLineOfSight() &&
                                                        u.IsTargetable)
                                            .OrderByDescending(r => r.GetResurrectionWeight());
@@ -457,12 +458,6 @@ namespace Magitek.Logic.WhiteMage
             var deadTarget = deadList.FirstOrDefault();
 
             if (deadTarget == null)
-                return false;
-
-            if (!deadTarget.IsVisible)
-                return false;
-
-            if (!deadTarget.IsTargetable)
                 return false;
 
             if (Core.Me.InCombat || Globals.OnPvpMap)


### PR DESCRIPTION
Minor raise tweaks.

This removes some redundant checks and eliminates the LineOfSight issue on raising if someone dies and you can't see them. This causes an error to show up on screen.