### PR TITLE
Fixed bug in PLD routine where Requiescat and Fight or Flight would be

### DIFF
--- a/Magitek/Logic/Paladin/Aoe.cs
+++ b/Magitek/Logic/Paladin/Aoe.cs
@@ -103,28 +103,5 @@ namespace Magitek.Logic.Paladin
 
             return await Spells.HolyCircle.Cast(Core.Me);
         }
-
-        public static async Task<bool> Confiteor()
-        {
-            if (!PaladinRoutine.ToggleAndSpellCheck(PaladinSettings.Instance.AoE, Spells.Confiteor))
-                return false;
-
-            if (ActionManager.CanCast(Spells.BladeOfFaith.Id, Core.Me.CurrentTarget))
-                return await Spells.BladeOfFaith.Cast(Core.Me.CurrentTarget);
-
-            if (ActionManager.CanCast(Spells.BladeOfTruth.Id, Core.Me.CurrentTarget))
-                return await Spells.BladeOfTruth.Cast(Core.Me.CurrentTarget);
-
-            if (ActionManager.CanCast(Spells.BladeOfValor.Id, Core.Me.CurrentTarget))
-                return await Spells.BladeOfValor.Cast(Core.Me.CurrentTarget);
-
-            // We want to Confit with our last stack, but if the req buff is
-            // about to fall off, and this is our last action, use confit
-            if (PaladinRoutine.RequiescatStackCount > 1
-                && Core.Me.HasAura(Auras.Requiescat, true, 3000))
-                return false;
-
-            return await Spells.Confiteor.Cast(Core.Me.CurrentTarget);
-        }
     }
 }

--- a/Magitek/Logic/Paladin/SingleTarget.cs
+++ b/Magitek/Logic/Paladin/SingleTarget.cs
@@ -166,6 +166,29 @@ namespace Magitek.Logic.Paladin
             return await Spells.Atonement.Cast(Core.Me.CurrentTarget);
         }
 
+        public static async Task<bool> Confiteor()
+        {
+            if (!PaladinRoutine.ToggleAndSpellCheck(PaladinSettings.Instance.UseConfiteor, Spells.Confiteor))
+                return false;
+
+            if (ActionManager.CanCast(Spells.BladeOfFaith.Id, Core.Me.CurrentTarget))
+                return await Spells.BladeOfFaith.Cast(Core.Me.CurrentTarget);
+
+            if (ActionManager.CanCast(Spells.BladeOfTruth.Id, Core.Me.CurrentTarget))
+                return await Spells.BladeOfTruth.Cast(Core.Me.CurrentTarget);
+
+            if (ActionManager.CanCast(Spells.BladeOfValor.Id, Core.Me.CurrentTarget))
+                return await Spells.BladeOfValor.Cast(Core.Me.CurrentTarget);
+
+            // We want to Confit with our last stack, but if the req buff is
+            // about to fall off, and this is our last action, use confit
+            if (PaladinRoutine.RequiescatStackCount > 1
+                && Core.Me.HasAura(Auras.Requiescat, true, 3000))
+                return false;
+
+            return await Spells.Confiteor.Cast(Core.Me.CurrentTarget);
+        }
+
         public static async Task<bool> Interrupt()
         {
             List<SpellData> extraStun = new List<SpellData>();

--- a/Magitek/Models/Paladin/PaladinSettings.cs
+++ b/Magitek/Models/Paladin/PaladinSettings.cs
@@ -66,6 +66,10 @@ namespace Magitek.Models.Paladin
 
         [Setting]
         [DefaultValue(true)]
+        public bool UseConfiteor { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
         public bool Requiescat { get; set; }
 
         [Setting]

--- a/Magitek/Rotations/Paladin.cs
+++ b/Magitek/Rotations/Paladin.cs
@@ -103,7 +103,7 @@ namespace Magitek.Rotations
                 }
 
                 if (await SingleTarget.ShieldLobLostAggro()) return true;
-                if (await Aoe.Confiteor()) return true;
+                if (await SingleTarget.Confiteor()) return true;
                 if (await Aoe.HolyCircle()) return true;
                 if (await Aoe.TotalEclipse()) return true;
                 if (await SingleTarget.HolySpirit()) return true;


### PR DESCRIPTION
used together during AOE situations. Moved Confiteor out of AOE into
SingleTarget and removed AOE toggle check, this aligns PLD with other
routines per Discord conversation. Added Toggle for UseConfiteor, but it
is not exposed in the UI yet.