### PR TITLE
MCH+WAR+GNB+BRD+DRG Update

### DIFF
--- a/Magitek/Logic/Bard/Aoe.cs
+++ b/Magitek/Logic/Bard/Aoe.cs
@@ -73,9 +73,6 @@ namespace Magitek.Logic.Bard
             if (!BardSettings.Instance.UseAoe)
                 return false;
 
-            if (!ActionManager.HasSpell(Spells.Shadowbite.Id))
-                return false;
-
             if (Core.Me.CurrentTarget.EnemiesNearby(5).Count() < BardSettings.Instance.ShadowBiteEnemies)
                 return false;
 
@@ -99,9 +96,6 @@ namespace Magitek.Logic.Bard
         public static async Task<bool> BlastArrow()
         {
             if (!BardSettings.Instance.UseBlastArrow)
-                return false;
-
-            if (!ActionManager.HasSpell(Spells.BlastArrow.Id))
                 return false;
 
             if (!Core.Me.HasAura(Auras.BlastArrowReady))

--- a/Magitek/Logic/Bard/Cooldowns.cs
+++ b/Magitek/Logic/Bard/Cooldowns.cs
@@ -20,11 +20,11 @@ namespace Magitek.Logic.Bard
             if (!BardSettings.Instance.UseRageingStrikes)
                 return false;
 
-            if (Spells.RagingStrikes.Cooldown != TimeSpan.Zero)
+            if (!Spells.RagingStrikes.IsReady())
                 return false;
 
             if (BardSettings.Instance.DelayRageingStrikesUntilBarrageIsReady)
-                if (Spells.Barrage.Cooldown != TimeSpan.Zero)
+                if (!Spells.Barrage.IsReady())
                     return false;
 
 
@@ -67,11 +67,10 @@ namespace Magitek.Logic.Bard
 
         public static async Task<bool> Barrage()
         {
-
-            if (Spells.Barrage.Cooldown != TimeSpan.Zero)
+            if (!BardSettings.Instance.UseBarrage)
                 return false;
 
-            if (!BardSettings.Instance.UseBarrage)
+            if (!Spells.Barrage.IsReady())
                 return false;
 
             //Dont Barrage when whe have a proc up

--- a/Magitek/Logic/Dragoon/Jumps.cs
+++ b/Magitek/Logic/Dragoon/Jumps.cs
@@ -11,7 +11,7 @@ namespace Magitek.Logic.Dragoon
 {
     internal static class Jumps
     {
-        public static async Task<bool> Execute()
+        private static bool CheckBeforeExecuteJumps()
         {
             if (!DragoonSettings.Instance.UseJumps)
                 return false;
@@ -28,10 +28,7 @@ namespace Magitek.Logic.Dragoon
             if (DragoonRoutine.JumpsList.Contains(Casting.LastSpell))
                 return false;
 
-            if (await HighJump()) return true;
-            if (await Stardiver()) return true;
-            if (await DragonfireDive()) return true;
-            return await SpineshatterDive();
+            return true;
         }
 
 
@@ -41,6 +38,9 @@ namespace Magitek.Logic.Dragoon
         public static async Task<bool> HighJump()
         {
             if (!DragoonSettings.Instance.UseHighJump)
+                return false;
+
+            if (!CheckBeforeExecuteJumps())
                 return false;
 
             if (RoutineManager.IsAnyDisallowed(CapabilityFlags.Movement))
@@ -54,13 +54,12 @@ namespace Magitek.Logic.Dragoon
             if (!DragoonSettings.Instance.UseMirageDive)
                 return false;
 
-            if (RoutineManager.IsAnyDisallowed(CapabilityFlags.Movement))
+            if (!CheckBeforeExecuteJumps())
                 return false;
 
             if (!Core.Me.HasAura(Auras.DiveReady))
                 return false;
 
-            // Don't mirage dive if at 2 eyes.
             if (ActionResourceManager.Dragoon.DragonGaze == 2)
                 return false;
 
@@ -72,7 +71,7 @@ namespace Magitek.Logic.Dragoon
             if (!DragoonSettings.Instance.UseSpineshatterDive)
                 return false;
 
-            if (RoutineManager.IsAnyDisallowed(CapabilityFlags.Movement))
+            if (!CheckBeforeExecuteJumps())
                 return false;
 
             if (Spells.SpineshatterDive.Charges <= 1 && Spells.LanceCharge.IsKnownAndReady(10000))
@@ -91,7 +90,7 @@ namespace Magitek.Logic.Dragoon
             if (!DragoonSettings.Instance.UseDragonfireDive)
                 return false;
 
-            if (RoutineManager.IsAnyDisallowed(CapabilityFlags.Movement))
+            if (!CheckBeforeExecuteJumps())
                 return false;
 
             if (!Core.Me.HasAura(Auras.LanceCharge))
@@ -103,6 +102,9 @@ namespace Magitek.Logic.Dragoon
         public static async Task<bool> Stardiver()
         {
             if (!DragoonSettings.Instance.UseStardiver)
+                return false;
+
+            if (!CheckBeforeExecuteJumps())
                 return false;
 
             return await Spells.Stardiver.Cast(Core.Me.CurrentTarget);

--- a/Magitek/Logic/Gunbreaker/Aoe.cs
+++ b/Magitek/Logic/Gunbreaker/Aoe.cs
@@ -17,7 +17,7 @@ namespace Magitek.Logic.Gunbreaker
          * ***********************************************************************************/
         public static async Task<bool> DemonSlice()
         {
-            if (!GunbreakerRoutine.ToggleAndSpellCheck(GunbreakerSettings.Instance.UseAoe, Spells.DemonSlice))
+            if (!GunbreakerSettings.Instance.UseAoe)
                 return false;
 
             if (Combat.Enemies.Count(r => r.Distance(Core.Me) <= 5 + r.CombatReach) < GunbreakerSettings.Instance.DemonSliceSlaughterEnemies)
@@ -31,7 +31,7 @@ namespace Magitek.Logic.Gunbreaker
 
         public static async Task<bool> DemonSlaughter()
         {
-            if (!GunbreakerRoutine.ToggleAndSpellCheck(GunbreakerSettings.Instance.UseAoe, Spells.DemonSlaughter))
+            if (!GunbreakerSettings.Instance.UseAoe)
                 return false;
 
             if (!GunbreakerRoutine.CanContinueComboAfter(Spells.DemonSlice))
@@ -43,6 +43,9 @@ namespace Magitek.Logic.Gunbreaker
             if (Combat.Enemies.Count(r => r.Distance(Core.Me) <= 5 + r.CombatReach) < GunbreakerSettings.Instance.DemonSliceSlaughterEnemies)
                 return false;
 
+            if (Cartridge == GunbreakerRoutine.MaxCartridge)
+                return false;
+
             return await Spells.DemonSlaughter.Cast(Core.Me.CurrentTarget);
         }
 
@@ -51,10 +54,10 @@ namespace Magitek.Logic.Gunbreaker
          * ***********************************************************************************/
         public static async Task<bool> FatedCircle()
         {
-            if (!GunbreakerRoutine.ToggleAndSpellCheck(GunbreakerSettings.Instance.UseFatedCircle, Spells.FatedCircle))
-                return false;
-
             if (!GunbreakerSettings.Instance.UseAoe)
+                return false; 
+            
+            if (!GunbreakerSettings.Instance.UseFatedCircle)
                 return false;
 
             if (Cartridge < GunbreakerRoutine.RequiredCartridgeForFatedCircle)
@@ -63,9 +66,35 @@ namespace Magitek.Logic.Gunbreaker
             if (GunbreakerRoutine.IsAurasForComboActive())
                 return false;
 
-            if (Combat.Enemies.Count(r => r.Distance(Core.Me) <= 5 + r.CombatReach) < GunbreakerSettings.Instance.FatedCircleEnemies)
+            if (Combat.Enemies.Count(r => r.Distance(Core.Me) <= 5 + r.CombatReach) < 2)
                 return false;
 
+            if (Core.Me.HasAura(Auras.NoMercy) && Cartridge > 0)
+            {
+                if (Spells.DoubleDown.IsKnownAndReady())
+                    return false;
+
+                if (Combat.Enemies.Count(r => r.Distance(Core.Me) <= 5 + r.CombatReach) < GunbreakerSettings.Instance.PrioritizeFatedCircleOverGnashingFangEnemies)
+                {
+                    if (Spells.GnashingFang.IsKnownAndReady())
+                        return false;
+                }
+            }
+
+            //Delay if nomercy ready soon
+            if (Spells.NoMercy.IsKnownAndReady(16000) && Cartridge < GunbreakerRoutine.MaxCartridge - 1)
+                return false;
+            if (Spells.NoMercy.IsKnownAndReady(8000) && Cartridge < GunbreakerRoutine.MaxCartridge)
+                return false;
+
+            //Delay if GnashingFang ready soon and there are less than GunbreakerSettings.Instance.PrioritizeFatedCircleOverGnashingFangEnemies
+            if (Combat.Enemies.Count(r => r.Distance(Core.Me) <= 5 + r.CombatReach) < GunbreakerSettings.Instance.PrioritizeFatedCircleOverGnashingFangEnemies)
+            {
+                if (Spells.GnashingFang.IsKnownAndReady(8000) && Cartridge <= GunbreakerRoutine.RequiredCartridgeForGnashingFang)
+                    return false;
+            }
+
+            //Delay if DoubleDown ready soon
             if (Spells.DoubleDown.IsKnownAndReady(4000) && Cartridge <= GunbreakerRoutine.RequiredCartridgeForDoubleDown)
                 return false;
 
@@ -77,7 +106,7 @@ namespace Magitek.Logic.Gunbreaker
          * ***********************************************************************************/
         public static async Task<bool> BowShock()
         {
-            if (!GunbreakerRoutine.ToggleAndSpellCheck(GunbreakerSettings.Instance.UseBowShock, Spells.BowShock))
+            if (!GunbreakerSettings.Instance.UseBowShock)
                 return false;
 
             if (!Core.Me.HasAura(Auras.NoMercy))
@@ -94,7 +123,7 @@ namespace Magitek.Logic.Gunbreaker
 
         public static async Task<bool> DoubleDown()
         {
-            if (!GunbreakerRoutine.ToggleAndSpellCheck(GunbreakerSettings.Instance.UseDoubleDown, Spells.DoubleDown))
+            if (!GunbreakerSettings.Instance.UseDoubleDown)
                 return false;
 
             if (!Core.Me.HasAura(Auras.NoMercy))

--- a/Magitek/Logic/Gunbreaker/Buff.cs
+++ b/Magitek/Logic/Gunbreaker/Buff.cs
@@ -1,6 +1,6 @@
 using ff14bot;
-using ff14bot.Managers;
 using Magitek.Extensions;
+using Magitek.Models.Account;
 using Magitek.Models.Gunbreaker;
 using Magitek.Utilities;
 using System.Threading.Tasks;
@@ -13,9 +13,6 @@ namespace Magitek.Logic.Gunbreaker
     {
         public static async Task<bool> RoyalGuard() //Tank stance
         {
-            if (!ActionManager.HasSpell(Spells.RoyalGuard.Id))
-                return false;
-
             switch (GunbreakerSettings.Instance.UseRoyalGuard)
             {
                 case true:
@@ -33,7 +30,11 @@ namespace Magitek.Logic.Gunbreaker
 
         public static async Task<bool> NoMercy() // Damage Buff +20%
         {
-            if (!GunbreakerRoutine.ToggleAndSpellCheck(GunbreakerSettings.Instance.UseNoMercy, Spells.NoMercy))
+            if (!GunbreakerSettings.Instance.UseNoMercy)
+                return false;
+
+            //Force Delay CD
+            if (Spells.KeenEdge.Cooldown.TotalMilliseconds > Globals.AnimationLockMs + BaseSettings.Instance.UserLatencyOffset + 100)
                 return false;
 
             return await Spells.NoMercy.Cast(Core.Me);
@@ -41,7 +42,7 @@ namespace Magitek.Logic.Gunbreaker
 
         public static async Task<bool> Bloodfest() // +2 or +3 cartrige
         {
-            if (!GunbreakerRoutine.ToggleAndSpellCheck(GunbreakerSettings.Instance.UseBloodfest, Spells.Bloodfest))
+            if (!GunbreakerSettings.Instance.UseBloodfest)
                 return false;
 
             if (Cartridge > GunbreakerRoutine.MaxCartridge - GunbreakerRoutine.AmountCartridgeFromBloodfest)

--- a/Magitek/Logic/Gunbreaker/Defensive.cs
+++ b/Magitek/Logic/Gunbreaker/Defensive.cs
@@ -32,7 +32,7 @@ namespace Magitek.Logic.Gunbreaker
 
         public static async Task<bool> Superbolide()
         {
-            if (!GunbreakerRoutine.ToggleAndSpellCheck(GunbreakerSettings.Instance.UseSuperbolide, Spells.Superbolide))
+            if (!GunbreakerSettings.Instance.UseSuperbolide)
                 return false;
 
             if (!UseDefensives())
@@ -46,7 +46,7 @@ namespace Magitek.Logic.Gunbreaker
 
         public static async Task<bool> Rampart()
         {
-            if (!GunbreakerRoutine.ToggleAndSpellCheck(GunbreakerSettings.Instance.UseRampart, Spells.Rampart))
+            if (!GunbreakerSettings.Instance.UseRampart)
                 return false;
 
             if (!UseDefensives())
@@ -60,7 +60,7 @@ namespace Magitek.Logic.Gunbreaker
 
         public static async Task<bool> Reprisal()
         {
-            if (!GunbreakerRoutine.ToggleAndSpellCheck(GunbreakerSettings.Instance.UseReprisal, Spells.Reprisal))
+            if (!GunbreakerSettings.Instance.UseReprisal)
                 return false;
 
             if (!UseDefensives())
@@ -74,7 +74,7 @@ namespace Magitek.Logic.Gunbreaker
 
         public static async Task<bool> Camouflage()
         {
-            if (!GunbreakerRoutine.ToggleAndSpellCheck(GunbreakerSettings.Instance.UseCamouflage, Spells.Camouflage))
+            if (!GunbreakerSettings.Instance.UseCamouflage)
                 return false;
 
             if (!UseDefensives())
@@ -88,7 +88,7 @@ namespace Magitek.Logic.Gunbreaker
 
         public static async Task<bool> Nebula()
         {
-            if (!GunbreakerRoutine.ToggleAndSpellCheck(GunbreakerSettings.Instance.UseNebula, Spells.Nebula))
+            if (!GunbreakerSettings.Instance.UseNebula)
                 return false;
 
             if (!UseDefensives())
@@ -102,7 +102,7 @@ namespace Magitek.Logic.Gunbreaker
 
         public static async Task<bool> HeartofLight()
         {
-            if (!GunbreakerRoutine.ToggleAndSpellCheck(GunbreakerSettings.Instance.UseHeartofLight, Spells.HeartofLight))
+            if (!GunbreakerSettings.Instance.UseHeartofLight)
                 return false;
 
             if (!UseDefensives())
@@ -116,7 +116,7 @@ namespace Magitek.Logic.Gunbreaker
 
         public static async Task<bool> HeartofCorundum()
         {
-            if (!GunbreakerRoutine.ToggleAndSpellCheck(GunbreakerSettings.Instance.UseHeartofCorundum, Spells.HeartOfCorundum))
+            if (!GunbreakerSettings.Instance.UseHeartofCorundum)
                 return false;
 
             if (!UseDefensives())

--- a/Magitek/Logic/Gunbreaker/Heal.cs
+++ b/Magitek/Logic/Gunbreaker/Heal.cs
@@ -12,12 +12,12 @@ namespace Magitek.Logic.Gunbreaker
     {
         public static async Task<bool> Aurora()
         {
-            if (!GunbreakerRoutine.ToggleAndSpellCheck(GunbreakerSettings.Instance.UseAurora, Spells.Aurora))
+            if (!GunbreakerSettings.Instance.UseAurora)
                 return false;
 
             if (GunbreakerSettings.Instance.UseAuroraSelf)
             {
-                if (Core.Me.CurrentHealthPercent < GunbreakerSettings.Instance.UseAuroraSelfHealthPercent)
+                if (Core.Me.CurrentHealthPercent < GunbreakerSettings.Instance.AuroraSelfHealthPercent)
                 {
                     return await Spells.Aurora.Cast(Core.Me);
                 }
@@ -50,7 +50,7 @@ namespace Magitek.Logic.Gunbreaker
             if (!GunbreakerSettings.Instance.UseAuroraSelf || anyHealers)
                 return false;
 
-            if (Core.Me.CurrentHealthPercent < GunbreakerSettings.Instance.UseAuroraSelfHealthPercent)
+            if (Core.Me.CurrentHealthPercent < GunbreakerSettings.Instance.AuroraSelfHealthPercent)
                 return await Spells.Aurora.Cast(Core.Me);
 
             return false;

--- a/Magitek/Logic/Gunbreaker/SingleTarget.cs
+++ b/Magitek/Logic/Gunbreaker/SingleTarget.cs
@@ -18,7 +18,7 @@ namespace Magitek.Logic.Gunbreaker
          *******************************************************************************/
         public static async Task<bool> LightningShot()
         {
-            if (!GunbreakerRoutine.ToggleAndSpellCheck(GunbreakerSettings.Instance.LightningShotToPullAggro, Spells.LightningShot))
+            if (!GunbreakerSettings.Instance.LightningShotToPullAggro)
                 return false;
 
             if (!Core.Me.HasAura(Auras.RoyalGuard))
@@ -49,9 +49,6 @@ namespace Magitek.Logic.Gunbreaker
          *******************************************************************************/
         public static async Task<bool> KeenEdge()
         {
-            if (!ActionManager.HasSpell(Spells.KeenEdge.Id))
-                return false;
-
             if (GunbreakerRoutine.IsAurasForComboActive())
                 return false;
 
@@ -60,9 +57,6 @@ namespace Magitek.Logic.Gunbreaker
 
         public static async Task<bool> BrutalShell()
         {
-            if (!ActionManager.HasSpell(Spells.BrutalShell.Id))
-                return false;
-
             if (!GunbreakerRoutine.CanContinueComboAfter(Spells.KeenEdge))
                 return false;
 
@@ -74,9 +68,6 @@ namespace Magitek.Logic.Gunbreaker
 
         public static async Task<bool> SolidBarrel()
         {
-            if (!ActionManager.HasSpell(Spells.SolidBarrel.Id))
-                return false;
-
             if (!GunbreakerRoutine.CanContinueComboAfter(Spells.BrutalShell))
                 return false;
 
@@ -95,13 +86,16 @@ namespace Magitek.Logic.Gunbreaker
          *******************************************************************************/
         public static async Task<bool> GnashingFang()
         {
-            if (!GunbreakerRoutine.ToggleAndSpellCheck(GunbreakerSettings.Instance.UseAmmoCombo, Spells.GnashingFang))
+            if (!GunbreakerSettings.Instance.UseAmmoCombo)
                 return false;
 
             if (GunbreakerRoutine.IsAurasForComboActive())
                 return false;
 
             if (Cartridge < GunbreakerRoutine.RequiredCartridgeForGnashingFang)
+                return false;
+
+            if (Combat.Enemies.Count(r => r.Distance(Core.Me) <= 5 + r.CombatReach) >= GunbreakerSettings.Instance.PrioritizeFatedCircleOverGnashingFangEnemies)
                 return false;
 
             if (Spells.NoMercy.IsKnownAndReady(10000))
@@ -112,9 +106,6 @@ namespace Magitek.Logic.Gunbreaker
 
         public static async Task<bool> SavageClaw()
         {
-            if (!ActionManager.HasSpell(Spells.SavageClaw.Id))
-                return false;
-
             if (SecondaryComboStage != 1)
                 return false;
 
@@ -126,9 +117,6 @@ namespace Magitek.Logic.Gunbreaker
 
         public static async Task<bool> WickedTalon()
         {
-            if (!ActionManager.HasSpell(Spells.WickedTalon.Id))
-                return false;
-
             if (SecondaryComboStage != 2)
                 return false;
 
@@ -144,9 +132,6 @@ namespace Magitek.Logic.Gunbreaker
          *******************************************************************************/
         public static async Task<bool> JugularRip()
         {
-            if (!ActionManager.HasSpell(Spells.JugularRip.Id))
-                return false;
-
             if (!Core.Me.HasAura(Auras.ReadytoRip))
                 return false;
 
@@ -155,9 +140,6 @@ namespace Magitek.Logic.Gunbreaker
 
         public static async Task<bool> AbdomenTear()
         {
-            if (!ActionManager.HasSpell(Spells.AbdomenTear.Id))
-                return false;
-
             if (!Core.Me.HasAura(Auras.ReadytoTear))
                 return false;
 
@@ -166,9 +148,6 @@ namespace Magitek.Logic.Gunbreaker
 
         public static async Task<bool> EyeGouge()
         {
-            if (!ActionManager.HasSpell(Spells.EyeGouge.Id))
-                return false;
-
             if (!Core.Me.HasAura(Auras.ReadytoGouge))
                 return false;
 
@@ -182,13 +161,16 @@ namespace Magitek.Logic.Gunbreaker
 
         public static async Task<bool> BurstStrike()
         {
-            if (!GunbreakerRoutine.ToggleAndSpellCheck(GunbreakerSettings.Instance.UseBurstStrike, Spells.BurstStrike))
+            if (!GunbreakerSettings.Instance.UseBurstStrike)
                 return false;
 
             if (GunbreakerRoutine.IsAurasForComboActive())
                 return false;
 
             if (Cartridge < GunbreakerRoutine.RequiredCartridgeForBurstStrike)
+                return false;
+
+            if (Combat.Enemies.Count(r => r.Distance(Core.Me) <= 5 + r.CombatReach) >= GunbreakerSettings.Instance.PrioritizeFatedCircleOverBurstStrikeEnemies)
                 return false;
 
             if (Core.Me.HasAura(Auras.NoMercy) && Cartridge > 0)
@@ -219,9 +201,6 @@ namespace Magitek.Logic.Gunbreaker
          *******************************************************************************/
         public static async Task<bool> Hypervelocity()
         {
-            if (!ActionManager.HasSpell(Spells.Hypervelocity.Id))
-                return false;
-
             if (!Core.Me.HasAura(Auras.ReadytoBlast))
                 return false;
 
@@ -234,9 +213,6 @@ namespace Magitek.Logic.Gunbreaker
          *******************************************************************************/
         public static async Task<bool> BlastingZone()
         {
-            if (!ActionManager.HasSpell(GunbreakerRoutine.BlastingZone.Id))
-                return false;
-
             if (GunbreakerSettings.Instance.SaveBlastingZone)
                 if (Spells.NoMercy.Cooldown.TotalMilliseconds <= GunbreakerSettings.Instance.SaveBlastingZoneMseconds)
                     return false;
@@ -250,7 +226,7 @@ namespace Magitek.Logic.Gunbreaker
 
         public static async Task<bool> RoughDivide() //Dash
         {
-            if (!GunbreakerRoutine.ToggleAndSpellCheck(GunbreakerSettings.Instance.UseRoughDivide, Spells.RoughDivide))
+            if (!GunbreakerSettings.Instance.UseRoughDivide)
                 return false;
 
             if (!Core.Me.HasAura(Auras.NoMercy))
@@ -268,9 +244,6 @@ namespace Magitek.Logic.Gunbreaker
          *******************************************************************************/
         public static async Task<bool> SonicBreak()
         {
-            if (!ActionManager.HasSpell(Spells.SonicBreak.Id))
-                return false;
-
             if (!Core.Me.HasAura(Auras.NoMercy))
                 return false;
 

--- a/Magitek/Logic/Machinist/Cooldowns.cs
+++ b/Magitek/Logic/Machinist/Cooldowns.cs
@@ -97,7 +97,7 @@ namespace Magitek.Logic.Machinist
                 return false;
 
             //Force Delay CD
-            if (Spells.SplitShot.Cooldown.TotalMilliseconds > Globals.AnimationLockMs + BaseSettings.Instance.UserLatencyOffset + 100)
+            if (Spells.SplitShot.Cooldown.TotalMilliseconds > Globals.AnimationLockMs + BaseSettings.Instance.UserLatencyOffset + 200)
                 return false;
 
             if (Core.Me.HasAura(Auras.WildfireBuff, true) || Casting.SpellCastHistory.Any(x => x.Spell == Spells.Wildfire))

--- a/Magitek/Logic/Machinist/Cooldowns.cs
+++ b/Magitek/Logic/Machinist/Cooldowns.cs
@@ -16,16 +16,13 @@ namespace Magitek.Logic.Machinist
     {
         public static async Task<bool> BarrelStabilizer()
         {
-            if (!MachinistRoutine.ToggleAndSpellCheck(MachinistSettings.Instance.UseBarrelStabilizer, Spells.BarrelStabilizer))
+            if (!MachinistSettings.Instance.UseBarrelStabilizer)
                 return false;
 
             if (!Core.Me.HasTarget)
                 return false;
 
-            if (!MachinistRoutine.IsInWeaveingWindow)
-                return false;
-
-            if (!Spells.BarrelStabilizer.IsKnownAndReady())
+            if (!Spells.BarrelStabilizer.IsReady())
                 return false;
 
             if (ActionResourceManager.Machinist.Heat > 30 && Spells.Wildfire.IsKnownAndReady(8000))
@@ -53,13 +50,14 @@ namespace Magitek.Logic.Machinist
         public static async Task<bool> Hypercharge()
         {
 
-            if (!MachinistRoutine.ToggleAndSpellCheck(MachinistSettings.Instance.UseHypercharge, Spells.Hypercharge))
-                return false;
-
-            if (!Spells.Hypercharge.IsKnownAndReady())
+            if (!MachinistSettings.Instance.UseHypercharge)
                 return false;
 
             if (ActionResourceManager.Machinist.Heat < 50)
+                return false;
+
+            //Force Delay CD
+            if (Spells.SplitShot.Cooldown.TotalMilliseconds > Globals.AnimationLockMs + BaseSettings.Instance.UserLatencyOffset + 100)
                 return false;
 
             if (Core.Me.ClassLevel >= 45)
@@ -86,20 +84,20 @@ namespace Magitek.Logic.Machinist
             if (Spells.Ricochet.Charges >= 2.5f || Spells.GaussRound.Charges >= 2.5f)
                 return false;
 
-            //Force Delay CD
-            if (Spells.SplitShot.Cooldown.TotalMilliseconds > 650 + BaseSettings.Instance.UserLatencyOffset)
-                return false;
-
             Logger.WriteInfo($@"Using Hypercharge at {Spells.SplitShot.Cooldown.TotalMilliseconds} ms before CD.");
             return await Spells.Hypercharge.Cast(Core.Me);
         }
 
         public static async Task<bool> Wildfire()
         {
-            if (!MachinistRoutine.ToggleAndSpellCheck(MachinistSettings.Instance.UseWildfire, Spells.Wildfire))
+            if (!MachinistSettings.Instance.UseWildfire)
                 return false;
 
-            if (!Spells.Wildfire.IsKnownAndReady())
+            if (!Spells.Wildfire.IsReady())
+                return false;
+
+            //Force Delay CD
+            if (Spells.SplitShot.Cooldown.TotalMilliseconds > Globals.AnimationLockMs + BaseSettings.Instance.UserLatencyOffset + 100)
                 return false;
 
             if (Core.Me.HasAura(Auras.WildfireBuff, true) || Casting.SpellCastHistory.Any(x => x.Spell == Spells.Wildfire))
@@ -117,28 +115,17 @@ namespace Magitek.Logic.Machinist
             if (ActionResourceManager.Machinist.Heat < 50 && ActionResourceManager.Machinist.OverheatRemaining == TimeSpan.Zero)
                 return false;
 
-            if (MachinistRoutine.GlobalCooldown.CountOGCDs() > 0)
-                return false;
-
-            //Force Delay CD
-            if (Spells.SplitShot.Cooldown.TotalMilliseconds > 1350 + BaseSettings.Instance.UserLatencyOffset)
-                return false;
-
             Logger.WriteInfo($@"Using Wildfire at {Spells.SplitShot.Cooldown.TotalMilliseconds} ms before CD.");
             return await Spells.Wildfire.Cast(Core.Me.CurrentTarget);
         }
 
         public static async Task<bool> Reassemble()
         {
-            if (!MachinistRoutine.ToggleAndSpellCheck(MachinistSettings.Instance.UseReassemble, Spells.Reassemble))
-                return false;
-
-            if (!MachinistRoutine.IsInWeaveingWindow)
+            if (!MachinistSettings.Instance.UseReassemble)
                 return false;
 
             // Added check for cooldown, gets stuck at lower levels otherwise.
-            if (Spells.Reassemble.Charges == 0
-                && Spells.Reassemble.Cooldown != TimeSpan.Zero)
+            if (Spells.Reassemble.Charges == 0 && !Spells.Reassemble.IsReady())
                 return false;
 
             //If we're in AoE logic, use Reassemble for SpreadShot
@@ -174,6 +161,5 @@ namespace Magitek.Logic.Machinist
 
             return await Spells.Reassemble.Cast(Core.Me);
         }
-
     }
 }

--- a/Magitek/Logic/Machinist/MultiTarget.cs
+++ b/Magitek/Logic/Machinist/MultiTarget.cs
@@ -14,7 +14,7 @@ namespace Magitek.Logic.Machinist
     {
         public static async Task<bool> Scattergun()
         {
-            if (!MachinistRoutine.ToggleAndSpellCheck(MachinistSettings.Instance.UseScattergun, MachinistRoutine.Scattergun))
+            if (!MachinistSettings.Instance.UseScattergun)
                 return false;
 
             if (!MachinistSettings.Instance.UseAoe)
@@ -31,7 +31,7 @@ namespace Magitek.Logic.Machinist
 
         public static async Task<bool> BioBlaster()
         {
-            if (!MachinistRoutine.ToggleAndSpellCheck(MachinistSettings.Instance.UseBioBlaster, Spells.Bioblaster))
+            if (!MachinistSettings.Instance.UseBioBlaster)
                 return false;
 
             if (!MachinistSettings.Instance.UseAoe)
@@ -48,7 +48,7 @@ namespace Magitek.Logic.Machinist
 
         public static async Task<bool> AutoCrossbow()
         {
-            if (!MachinistRoutine.ToggleAndSpellCheck(MachinistSettings.Instance.UseAutoCrossbow, Spells.AutoCrossbow))
+            if (!MachinistSettings.Instance.UseAutoCrossbow)
                 return false;
 
             if (!MachinistSettings.Instance.UseAoe)
@@ -64,7 +64,7 @@ namespace Magitek.Logic.Machinist
         }
         public static async Task<bool> Flamethrower()
         {
-            if (!MachinistRoutine.ToggleAndSpellCheck(MachinistSettings.Instance.UseFlamethrower, Spells.Flamethrower))
+            if (!MachinistSettings.Instance.UseFlamethrower)
                 return false;
 
             if (!MachinistSettings.Instance.UseAoe)
@@ -95,10 +95,7 @@ namespace Magitek.Logic.Machinist
         }
         public static async Task<bool> Ricochet()
         {
-            if (!MachinistRoutine.ToggleAndSpellCheck(MachinistSettings.Instance.UseRicochet, Spells.Ricochet))
-                return false;
-
-            if (!MachinistRoutine.IsInWeaveingWindow)
+            if (!MachinistSettings.Instance.UseRicochet)
                 return false;
 
             if (Casting.LastSpell == Spells.Wildfire || Casting.LastSpell == Spells.Hypercharge)
@@ -125,7 +122,7 @@ namespace Magitek.Logic.Machinist
 
         public static async Task<bool> ChainSaw()
         {
-            if (!MachinistRoutine.ToggleAndSpellCheck(MachinistSettings.Instance.UseChainSaw, Spells.ChainSaw))
+            if (!MachinistSettings.Instance.UseChainSaw)
                 return false;
 
             if (ActionResourceManager.Machinist.OverheatRemaining > TimeSpan.Zero)

--- a/Magitek/Logic/Machinist/Pet.cs
+++ b/Magitek/Logic/Machinist/Pet.cs
@@ -5,7 +5,7 @@ using Magitek.Models.Machinist;
 using Magitek.Utilities;
 using System;
 using System.Threading.Tasks;
-using MachinistGlobals = Magitek.Utilities.Routines.Machinist;
+using MachinistRoutine = Magitek.Utilities.Routines.Machinist;
 
 namespace Magitek.Logic.Machinist
 {
@@ -22,19 +22,16 @@ namespace Magitek.Logic.Machinist
             if (ActionResourceManager.Machinist.OverheatRemaining > TimeSpan.Zero)
                 return false;
 
-            if (!MachinistGlobals.IsInWeaveingWindow)
-                return false;
-
             if (ActionResourceManager.Machinist.Battery < MachinistSettings.Instance.MinBatteryForPetSummon)
                 return false;
 
             if (MachinistSettings.Instance.UseBuffedRookQueen)
             {
-                if (!Utilities.Routines.Machinist.CheckCurrentDamageIncrease(MachinistSettings.Instance.UseRookQueenWithAtLeastXBonusDamage) && ActionResourceManager.Machinist.Battery < 80)
+                if (!MachinistRoutine.CheckCurrentDamageIncrease(MachinistSettings.Instance.UseRookQueenWithAtLeastXBonusDamage) && ActionResourceManager.Machinist.Battery < 80)
                     return false;
             }
 
-            return await MachinistGlobals.RookQueenPet.Cast(Core.Me);
+            return await MachinistRoutine.RookQueenPet.Cast(Core.Me);
         }
 
         public static async Task<bool> RookQueenOverdrive()
@@ -43,7 +40,7 @@ namespace Magitek.Logic.Machinist
                 return false;
 
             if (Core.Me.CurrentTarget.CombatTimeLeft() <= 2 && Core.Me.CurrentTarget.CurrentHealthPercent < 2)
-                return await MachinistGlobals.RookQueenOverdrive.Cast(Core.Me.CurrentTarget);
+                return await MachinistRoutine.RookQueenOverdrive.Cast(Core.Me.CurrentTarget);
 
             return false;
         }

--- a/Magitek/Logic/Machinist/SingleTarget.cs
+++ b/Magitek/Logic/Machinist/SingleTarget.cs
@@ -15,7 +15,7 @@ namespace Magitek.Logic.Machinist
         public static async Task<bool> HeatedSplitShot()
         {
             //One to disable them all
-            if (!MachinistRoutine.ToggleAndSpellCheck(MachinistSettings.Instance.UseSplitShotCombo, MachinistRoutine.HeatedSplitShot))
+            if (!MachinistSettings.Instance.UseSplitShotCombo)
                 return false;
 
             if (MachinistSettings.Instance.UseDrill && Spells.Drill.IsKnownAndReady(200))
@@ -35,9 +35,6 @@ namespace Magitek.Logic.Machinist
 
         public static async Task<bool> HeatedSlugShot()
         {
-            if (!ActionManager.HasSpell(MachinistRoutine.HeatedSlugShot.Id))
-                return false;
-
             if (!MachinistRoutine.CanContinueComboAfter(Spells.SplitShot))
                 return false;
 
@@ -58,9 +55,6 @@ namespace Magitek.Logic.Machinist
 
         public static async Task<bool> HeatedCleanShot()
         {
-            if (!ActionManager.HasSpell(MachinistRoutine.HeatedCleanShot.Id))
-                return false;
-
             if (!MachinistRoutine.CanContinueComboAfter(Spells.SlugShot))
                 return false;
 
@@ -81,7 +75,7 @@ namespace Magitek.Logic.Machinist
 
         public static async Task<bool> Drill()
         {
-            if (!MachinistRoutine.ToggleAndSpellCheck(MachinistSettings.Instance.UseDrill, Spells.Drill))
+            if (!MachinistSettings.Instance.UseDrill)
                 return false;
 
             if (ActionResourceManager.Machinist.OverheatRemaining > TimeSpan.Zero)
@@ -95,7 +89,7 @@ namespace Magitek.Logic.Machinist
 
         public static async Task<bool> HotAirAnchor()
         {
-            if (!MachinistRoutine.ToggleAndSpellCheck(MachinistSettings.Instance.UseHotAirAnchor, MachinistRoutine.HotAirAnchor))
+            if (!MachinistSettings.Instance.UseHotAirAnchor)
                 return false;
 
             if (ActionResourceManager.Machinist.OverheatRemaining > TimeSpan.Zero)
@@ -121,9 +115,6 @@ namespace Magitek.Logic.Machinist
         public static async Task<bool> GaussRound()
         {
             if (!MachinistSettings.Instance.UseGaussRound)
-                return false;
-
-            if (!MachinistRoutine.IsInWeaveingWindow)
                 return false;
 
             if (Casting.LastSpell == Spells.Wildfire || Casting.LastSpell == Spells.Hypercharge)

--- a/Magitek/Logic/Machinist/Utility.cs
+++ b/Magitek/Logic/Machinist/Utility.cs
@@ -16,7 +16,9 @@ namespace Magitek.Logic.Machinist
             if (!MachinistSettings.Instance.ForceTactician)
                 return false;
 
-            if (!await Spells.Tactician.Cast(Core.Me)) return false;
+            if (!await Spells.Tactician.Cast(Core.Me)) 
+                return false;
+
             MachinistSettings.Instance.ForceTactician = false;
             TogglesManager.ResetToggles();
             return true;

--- a/Magitek/Logic/Warrior/Aoe.cs
+++ b/Magitek/Logic/Warrior/Aoe.cs
@@ -13,7 +13,7 @@ namespace Magitek.Logic.Warrior
     {
         public static async Task<bool> ChaoticCyclone()
         {
-            if (!WarriorRoutine.ToggleAndSpellCheck(WarriorSettings.Instance.UseAoe, Spells.ChaoticCyclone))
+            if (!WarriorSettings.Instance.UseAoe)
                 return false;
 
             if (!Core.Me.HasAura(Auras.NascentChaos))
@@ -31,7 +31,7 @@ namespace Magitek.Logic.Warrior
 
         public static async Task<bool> Decimate()
         {
-            if (!WarriorRoutine.ToggleAndSpellCheck(WarriorSettings.Instance.UseAoe, Spells.Decimate))
+            if (!WarriorSettings.Instance.UseAoe)
                 return false;
 
             if (!WarriorSettings.Instance.UseDecimate)
@@ -55,7 +55,7 @@ namespace Magitek.Logic.Warrior
 
         public static async Task<bool> Overpower()
         {
-            if (!WarriorRoutine.ToggleAndSpellCheck(WarriorSettings.Instance.UseAoe, Spells.Overpower))
+            if (!WarriorSettings.Instance.UseAoe)
                 return false;
 
             if (Combat.Enemies.Count(r => r.Distance(Core.Me) <= 8 + r.CombatReach) < WarriorSettings.Instance.OverpowerMinimumEnemies)
@@ -66,7 +66,7 @@ namespace Magitek.Logic.Warrior
 
         public static async Task<bool> MythrilTempest()
         {
-            if (!WarriorRoutine.ToggleAndSpellCheck(WarriorSettings.Instance.UseAoe, Spells.MythrilTempest))
+            if (!WarriorSettings.Instance.UseAoe)
                 return false;
 
             if (!WarriorRoutine.CanContinueComboAfter(Spells.Overpower))
@@ -80,10 +80,10 @@ namespace Magitek.Logic.Warrior
 
         public static async Task<bool> Orogeny()
         {
-            if (!WarriorRoutine.ToggleAndSpellCheck(WarriorSettings.Instance.UseAoe, Spells.Orogeny))
+            if (!WarriorSettings.Instance.UseAoe)
                 return false;
 
-            if (!Spells.Orogeny.IsKnownAndReady())
+            if (!Spells.Orogeny.IsReady())
                 return false;
 
             if (!Core.Me.HasAura(Auras.SurgingTempest))
@@ -97,7 +97,7 @@ namespace Magitek.Logic.Warrior
 
         public static async Task<bool> PrimalRend()
         {
-            if (!WarriorRoutine.ToggleAndSpellCheck(WarriorSettings.Instance.UseAoe, Spells.PrimalRend))
+            if (!WarriorSettings.Instance.UseAoe)
                 return false;
 
             if (!WarriorSettings.Instance.UsePrimalRend)

--- a/Magitek/Logic/Warrior/Buff.cs
+++ b/Magitek/Logic/Warrior/Buff.cs
@@ -32,20 +32,11 @@ namespace Magitek.Logic.Warrior
 
             return await Spells.Defiance.Cast(Core.Me);
         }
-        internal static async Task<bool> Equilibrium()
-        {
-            if (!WarriorRoutine.ToggleAndSpellCheck(WarriorSettings.Instance.UseEquilibrium, Spells.Equilibrium))
-                return false;
 
-            if (Core.Me.CurrentHealthPercent > WarriorSettings.Instance.EquilibriumHealthPercent)
-                return false;
-
-            return await Spells.Equilibrium.Cast(Core.Me);
-        }
         //Berserk Becomes Inner Release
-        internal static async Task<bool> InnerRelease()
+        public static async Task<bool> InnerRelease()
         {
-            if (!WarriorRoutine.ToggleAndSpellCheck(WarriorSettings.Instance.UseInnerRelease, WarriorRoutine.InnerRelease))
+            if (!WarriorSettings.Instance.UseInnerRelease)
                 return false;
 
             if (Core.Me.CurrentTarget == null)
@@ -68,12 +59,12 @@ namespace Magitek.Logic.Warrior
             }
 
             //Logger.WriteInfo($@"InnerRelease Ready");
-            return await Utilities.Routines.Warrior.InnerRelease.Cast(Core.Me);
+            return await WarriorRoutine.InnerRelease.Cast(Core.Me);
         }
 
-        internal static async Task<bool> Infuriate()
+        public static async Task<bool> Infuriate()
         {
-            if (!WarriorRoutine.ToggleAndSpellCheck(WarriorSettings.Instance.UseInfuriate, Spells.Infuriate))
+            if (!WarriorSettings.Instance.UseInfuriate)
                 return false;
 
             if (Casting.LastSpell == Spells.InnerRelease)
@@ -91,13 +82,13 @@ namespace Magitek.Logic.Warrior
 
         public static async Task<bool> NascentFlash()
         {
-            if (!WarriorRoutine.ToggleAndSpellCheck(WarriorSettings.Instance.UseNascentFlash, Spells.NascentFlash))
+            if (!WarriorSettings.Instance.UseNascentFlash)
                 return false;
 
             if (!Globals.InParty)
                 return false;
 
-            if (Spells.NascentFlash.Cooldown != System.TimeSpan.Zero)
+            if (!Spells.NascentFlash.IsReady())
                 return false;
 
             var canNascentTargets = Group.CastableAlliesWithin30.Where(CanNascentFlash).OrderByDescending(DispelManager.GetWeight).ThenBy(c => c.CurrentHealthPercent).ToList();

--- a/Magitek/Logic/Warrior/Defensive.cs
+++ b/Magitek/Logic/Warrior/Defensive.cs
@@ -31,7 +31,7 @@ namespace Magitek.Logic.Warrior
 
         public static async Task<bool> Holmgang()
         {
-            if (!WarriorRoutine.ToggleAndSpellCheck(WarriorSettings.Instance.UseHolmgang, Spells.Holmgang))
+            if (!WarriorSettings.Instance.UseHolmgang)
                 return false;
 
             if (!UseDefensives())
@@ -45,7 +45,7 @@ namespace Magitek.Logic.Warrior
 
         public static async Task<bool> Reprisal()
         {
-            if (!WarriorRoutine.ToggleAndSpellCheck(WarriorSettings.Instance.UseReprisal, Spells.Reprisal))
+            if (!WarriorSettings.Instance.UseReprisal)
                 return false;
 
             if (!UseDefensives())
@@ -59,7 +59,7 @@ namespace Magitek.Logic.Warrior
 
         public static async Task<bool> Rampart()
         {
-            if (!WarriorRoutine.ToggleAndSpellCheck(WarriorSettings.Instance.UseRampart, Spells.Rampart))
+            if (!WarriorSettings.Instance.UseRampart)
                 return false;
 
             if (!UseDefensives())
@@ -73,7 +73,7 @@ namespace Magitek.Logic.Warrior
 
         public static async Task<bool> Vengeance()
         {
-            if (!WarriorRoutine.ToggleAndSpellCheck(WarriorSettings.Instance.UseVengeance, Spells.Vengeance))
+            if (!WarriorSettings.Instance.UseVengeance)
                 return false;
 
             if (!UseDefensives())
@@ -87,7 +87,7 @@ namespace Magitek.Logic.Warrior
 
         public static async Task<bool> ShakeItOff()
         {
-            if (!WarriorRoutine.ToggleAndSpellCheck(WarriorSettings.Instance.UseShakeItOff, Spells.ShakeItOff))
+            if (!WarriorSettings.Instance.UseShakeItOff)
                 return false;
 
             if (!UseDefensives())
@@ -99,23 +99,9 @@ namespace Magitek.Logic.Warrior
             return await Spells.ShakeItOff.Cast(Core.Me);
         }
 
-        public static async Task<bool> ThrillOfBattle()
-        {
-            if (!WarriorRoutine.ToggleAndSpellCheck(WarriorSettings.Instance.UseThrillOfBattle, Spells.ThrillofBattle))
-                return false;
-
-            if (!UseDefensives())
-                return false;
-
-            if (Core.Me.CurrentHealthPercent > WarriorSettings.Instance.ThrillOfBattleHpPercentage)
-                return false;
-
-            return await Spells.ThrillofBattle.CastAura(Core.Me, Auras.ThrillOfBattle);
-        }
-
         public static async Task<bool> BloodWhetting()
         {
-            if (!WarriorRoutine.ToggleAndSpellCheck(WarriorSettings.Instance.UseBloodWhetting, WarriorRoutine.Bloodwhetting))
+            if (!WarriorSettings.Instance.UseBloodWhetting)
                 return false;
 
             if (Core.Me.CurrentHealthPercent > WarriorSettings.Instance.BloodWhettingHpPercentage)

--- a/Magitek/Logic/Warrior/Heal.cs
+++ b/Magitek/Logic/Warrior/Heal.cs
@@ -1,0 +1,60 @@
+﻿using ff14bot;
+using Magitek.Extensions;
+using Magitek.Models.Warrior;
+using Magitek.Utilities;
+using System.Linq;
+using System.Threading.Tasks;
+using WarriorRoutine = Magitek.Utilities.Routines.Warrior;
+
+namespace Magitek.Logic.Warrior
+{
+    internal static class Heal
+    {
+        private static bool UseHeal()
+        {
+            if (!WarriorSettings.Instance.UseHeal)
+                return false;
+
+            var currentAuras = Core.Me.CharacterAuras.Select(r => r.Id).Where(r => WarriorRoutine.Heal.Contains(r)).ToList();
+
+            if (currentAuras.Count >= WarriorSettings.Instance.MaxHealAtOnce)
+            {
+                if (currentAuras.Count >= WarriorSettings.Instance.MaxHealUnderHp)
+                    return false;
+
+                if (Core.Me.CurrentHealthPercent >= WarriorSettings.Instance.MoreHealHp)
+                    return false;
+            }
+
+            return true;
+        }
+
+        public static async Task<bool> Equilibrium()
+        {
+            if (!WarriorSettings.Instance.UseEquilibrium)
+                return false;
+
+            if (!UseHeal())
+                return false;
+
+            if (Core.Me.CurrentHealthPercent > WarriorSettings.Instance.EquilibriumHealthPercent)
+                return false;
+
+            return await Spells.Equilibrium.Cast(Core.Me);
+        }
+
+        public static async Task<bool> ThrillOfBattle()
+        {
+            if (!WarriorSettings.Instance.UseThrillOfBattle)
+                return false;
+
+            if (!UseHeal())
+                return false;
+
+            if (Core.Me.CurrentHealthPercent > WarriorSettings.Instance.ThrillOfBattleHpPercentage)
+                return false;
+
+            return await Spells.ThrillofBattle.CastAura(Core.Me, Auras.ThrillOfBattle);
+        }
+    }
+}

--- a/Magitek/Logic/Warrior/SingleTarget.cs
+++ b/Magitek/Logic/Warrior/SingleTarget.cs
@@ -74,9 +74,6 @@ namespace Magitek.Logic.Warrior
          * ***********************************************************************************/
         public static async Task<bool> StormsPath()
         {
-            if (!ActionManager.HasSpell(Spells.StormsPath.Id))
-                return false;
-
             if (!WarriorRoutine.CanContinueComboAfter(Spells.Maim))
                 return false;
 
@@ -85,9 +82,6 @@ namespace Magitek.Logic.Warrior
 
         public static async Task<bool> StormsEye()
         {
-            if (!ActionManager.HasSpell(Spells.StormsEye.Id))
-                return false;
-
             if (!WarriorRoutine.CanContinueComboAfter(Spells.Maim))
                 return false;
 
@@ -111,9 +105,6 @@ namespace Magitek.Logic.Warrior
 
         public static async Task<bool> Maim()
         {
-            if (!ActionManager.HasSpell(Spells.Maim.Id))
-                return false;
-
             if (!WarriorRoutine.CanContinueComboAfter(Spells.HeavySwing))
                 return false;
 
@@ -122,9 +113,6 @@ namespace Magitek.Logic.Warrior
 
         public static async Task<bool> HeavySwing()
         {
-            if (!ActionManager.HasSpell(Spells.HeavySwing.Id))
-                return false;
-
             if (Core.Me.HasAura(Auras.InnerRelease))
                 return false;
 
@@ -137,10 +125,10 @@ namespace Magitek.Logic.Warrior
          * ***********************************************************************************/
         public static async Task<bool> Upheaval()
         {
-            if (!WarriorRoutine.ToggleAndSpellCheck(WarriorSettings.Instance.UseUpheaval, Spells.Upheaval))
+            if (!WarriorSettings.Instance.UseUpheaval)
                 return false;
 
-            if (!Spells.Upheaval.IsKnownAndReady())
+            if (!Spells.Upheaval.IsReady())
                 return false;
 
             if (!Core.Me.HasAura(Auras.SurgingTempest))
@@ -154,7 +142,7 @@ namespace Magitek.Logic.Warrior
 
         public static async Task<bool> Onslaught()
         {
-            if (!WarriorRoutine.ToggleAndSpellCheck(WarriorSettings.Instance.UseOnslaught, Spells.Onslaught))
+            if (!WarriorSettings.Instance.UseOnslaught)
                 return false;
 
             if (!Core.Me.HasAura(Auras.InnerRelease))
@@ -163,7 +151,7 @@ namespace Magitek.Logic.Warrior
             if (Combat.Enemies.Count(r => r.Distance(Core.Me) <= 3 + r.CombatReach) > 1)
                 return false;
 
-            if (WarriorRoutine.GlobalCooldown.CountOGCDs() > 0)
+            if (!WarriorRoutine.GlobalCooldown.CanWeave(1))
                 return false;
 
             return await Spells.Onslaught.Cast(Core.Me.CurrentTarget);
@@ -174,9 +162,6 @@ namespace Magitek.Logic.Warrior
          * ***********************************************************************************/
         public static async Task<bool> FellCleave()
         {
-            if (!ActionManager.HasSpell(Spells.FellCleave.Id))
-                return false;
-
             if (Core.Me.HasAura(Auras.NascentChaos))
                 return false;
 
@@ -191,7 +176,7 @@ namespace Magitek.Logic.Warrior
 
         public static async Task<bool> InnerChaos()
         {
-            if (!WarriorRoutine.ToggleAndSpellCheck(WarriorSettings.Instance.UseInnerChaos, Spells.InnerChaos))
+            if (!WarriorSettings.Instance.UseInnerChaos)
                 return false;
 
             if (!Core.Me.HasAura(Auras.NascentChaos))

--- a/Magitek/Magitek.csproj
+++ b/Magitek/Magitek.csproj
@@ -258,6 +258,7 @@
     <Compile Include="Logic\Sage\Dispel.cs" />
     <Compile Include="Logic\Sage\Heal.cs" />
     <Compile Include="Logic\Sage\SingleTarget.cs" />
+    <Compile Include="Logic\Warrior\Heal.cs" />
     <Compile Include="Models\Reaper\ReaperSettings.cs" />
     <Compile Include="Models\Sage\SageSettings.cs" />
     <Compile Include="Rotations\Reaper.cs" />
@@ -809,6 +810,9 @@
     </Compile>
     <Compile Include="Views\UserControls\Warrior\Defensives.xaml.cs">
       <DependentUpon>Defensives.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Views\UserControls\Warrior\Healing.xaml.cs">
+      <DependentUpon>Healing.xaml</DependentUpon>
     </Compile>
     <Compile Include="Views\UserControls\WhiteMage\Alliance.xaml.cs">
       <DependentUpon>Alliance.xaml</DependentUpon>
@@ -1364,6 +1368,10 @@
     <Page Include="Views\UserControls\Warrior\Defensives.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Views\UserControls\Warrior\Healing.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
     </Page>
     <Page Include="Views\UserControls\WhiteMage\Alliance.xaml">
       <SubType>Designer</SubType>

--- a/Magitek/Models/Gunbreaker/GunbreakerSettings.cs
+++ b/Magitek/Models/Gunbreaker/GunbreakerSettings.cs
@@ -12,90 +12,40 @@ namespace Magitek.Models.Gunbreaker
 
         public static GunbreakerSettings Instance { get; set; } = new GunbreakerSettings();
 
-        [Setting]
-        [DefaultValue(true)]
-        public bool UseAmmoCombo { get; set; }
-
+        #region General
         [Setting]
         [DefaultValue(true)]
         public bool UseRoyalGuard { get; set; }
 
         [Setting]
         [DefaultValue(true)]
-        public bool UseSuperbolide { get; set; }
-
-        [Setting]
-        [DefaultValue(5)]
-        public int SuperbolideHealthPercent { get; set; }
+        public bool UseAmmoCombo { get; set; }
 
         [Setting]
         [DefaultValue(true)]
-        public bool UseCamouflage { get; set; }
-
-        [Setting]
-        [DefaultValue(10)]
-        public int CamouflageHealthPercent { get; set; }
+        public bool UseBowShock { get; set; }
 
         [Setting]
         [DefaultValue(true)]
-        public bool UseNebula { get; set; }
-
-        [Setting]
-        [DefaultValue(30)]
-        public int NebulaHealthPercent { get; set; }
+        public bool UseRoughDivide { get; set; }
 
         [Setting]
         [DefaultValue(true)]
-        public bool UseHeartofLight { get; set; }
-
-        [Setting]
-        [DefaultValue(10)]
-        public int HeartofLightHealthPercent { get; set; }
+        public bool UseBloodfest { get; set; }
 
         [Setting]
         [DefaultValue(true)]
-        public bool UseHeartofCorundum { get; set; }
+        public bool UseBurstStrike { get; set; }
 
-        [Setting]
-        [DefaultValue(15)]
-        public int HeartofCorundumHealthPercent { get; set; }
+        #endregion
 
-        [Setting]
-        [DefaultValue(true)]
-        public bool UseAurora { get; set; }
-
+        #region Buff
         [Setting]
         [DefaultValue(true)]
-        public bool UseAuroraHealer { get; set; }
+        public bool UseNoMercy { get; set; }
+        #endregion
 
-        [Setting]
-        [DefaultValue(30)]
-        public int UseAuroraHealerHealthPercent { get; set; }
-
-        [Setting]
-        [DefaultValue(true)]
-        public bool UseAuroraDps { get; set; }
-
-        [Setting]
-        [DefaultValue(30)]
-        public int UseAuroraDpsHealthPercent { get; set; }
-
-        [Setting]
-        [DefaultValue(true)]
-        public bool UseAuroraSelf { get; set; }
-
-        [Setting]
-        [DefaultValue(30)]
-        public int UseAuroraSelfHealthPercent { get; set; }
-
-        [Setting]
-        [DefaultValue(15)]
-        public int AuroraAsDefensiveHealthPercent { get; set; }
-
-        [Setting]
-        [DefaultValue(50)]
-        public int MinMpAurora { get; set; }
-
+        #region AOE
         [Setting]
         [DefaultValue(true)]
         public bool UseAoe { get; set; }
@@ -109,25 +59,103 @@ namespace Magitek.Models.Gunbreaker
         public bool UseFatedCircle { get; set; }
 
         [Setting]
-        [DefaultValue(true)]
-        public bool UseBowShock { get; set; }
+        [DefaultValue(3)]
+        public int PrioritizeFatedCircleOverGnashingFangEnemies { get; set; }
 
         [Setting]
         [DefaultValue(2)]
-        public int FatedCircleEnemies { get; set; }
+        public int PrioritizeFatedCircleOverBurstStrikeEnemies { get; set; }
 
         [Setting]
         [DefaultValue(true)]
-        public bool UseNoMercy { get; set; }
+        public bool UseDoubleDown { get; set; }
+
+        [Setting]
+        [DefaultValue(1)]
+        public int DoubleDownEnemies { get; set; }
+        #endregion
+
+        #region Defensives
+        [Setting]
+        [DefaultValue(true)]
+        public bool UseSuperbolide { get; set; }
+
+        [Setting]
+        [DefaultValue(20)]
+        public int SuperbolideHealthPercent { get; set; }
 
         [Setting]
         [DefaultValue(true)]
-        public bool UseRoughDivide { get; set; }
+        public bool UseCamouflage { get; set; }
+
+        [Setting]
+        [DefaultValue(80)]
+        public int CamouflageHealthPercent { get; set; }
 
         [Setting]
         [DefaultValue(true)]
-        public bool UseBloodfest { get; set; }
+        public bool UseNebula { get; set; }
 
+        [Setting]
+        [DefaultValue(70)]
+        public int NebulaHealthPercent { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
+        public bool UseHeartofLight { get; set; }
+
+        [Setting]
+        [DefaultValue(60)]
+        public int HeartofLightHealthPercent { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
+        public bool UseHeartofCorundum { get; set; }
+
+        [Setting]
+        [DefaultValue(60)]
+        public int HeartofCorundumHealthPercent { get; set; }
+        #endregion
+
+        #region Heal
+        [Setting]
+        [DefaultValue(true)]
+        public bool UseAurora { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
+        public bool UseAuroraHealer { get; set; }
+
+        [Setting]
+        [DefaultValue(40)]
+        public int UseAuroraHealerHealthPercent { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
+        public bool UseAuroraDps { get; set; }
+
+        [Setting]
+        [DefaultValue(40)]
+        public int UseAuroraDpsHealthPercent { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
+        public bool UseAuroraSelf { get; set; }
+
+        [Setting]
+        [DefaultValue(70)]
+        public int AuroraSelfHealthPercent { get; set; }
+
+        [Setting]
+        [DefaultValue(70)]
+        public int AuroraAsDefensiveHealthPercent { get; set; }
+
+        [Setting]
+        [DefaultValue(50)]
+        public int MinMpAurora { get; set; }
+        #endregion
+
+        #region Pull
         [Setting]
         [DefaultValue(true)]
         public bool PullWithLightningShot { get; set; }
@@ -140,6 +168,21 @@ namespace Magitek.Models.Gunbreaker
         [DefaultValue(true)]
         public bool LightningShotToPullAggro { get; set; }
 
+        #endregion
+
+
+
+
+
+
+
+
+
+
+
+
+
+
         [Setting]
         [DefaultValue(true)]
         public bool SaveBlastingZone { get; set; }
@@ -148,16 +191,8 @@ namespace Magitek.Models.Gunbreaker
         [DefaultValue(6000)]
         public int SaveBlastingZoneMseconds { get; set; }
 
-        [Setting]
-        [DefaultValue(true)]
-        public bool UseDoubleDown { get; set; }
+        
 
-        [Setting]
-        [DefaultValue(1)]
-        public int DoubleDownEnemies { get; set; }
-
-        [Setting]
-        [DefaultValue(true)]
-        public bool UseBurstStrike { get; set; }
+        
     }
 }

--- a/Magitek/Models/Machinist/MachinistSettings.cs
+++ b/Magitek/Models/Machinist/MachinistSettings.cs
@@ -146,6 +146,9 @@ namespace Magitek.Models.Machinist
         [DefaultValue(true)]
         public bool ForceTactician { get; internal set; }
 
+        [Setting]
+        [DefaultValue(70.0f)]
+        public float RestHealthPercent { get; set; }
         #endregion
 
 

--- a/Magitek/Models/Roles/TankSettings.cs
+++ b/Magitek/Models/Roles/TankSettings.cs
@@ -11,19 +11,13 @@ namespace Magitek.Models.Roles
     {
         protected TankSettings(string path) : base(path)
         {
+
         }
 
-        /*[Setting]
-        [DefaultValue(true)]
-        //public bool UseTankBusters { get; set; }*/
-
+        #region defensive
         [Setting]
         [DefaultValue(true)]
         public bool UseDefensives { get; set; }
-
-        /*[Setting]
-        [DefaultValue(false)]
-        //public bool UseDefensivesOnlyOnTankBusters { get; set; }*/
 
         [Setting]
         [DefaultValue(1)]
@@ -36,10 +30,6 @@ namespace Magitek.Models.Roles
         [Setting]
         [DefaultValue(50.0f)]
         public float MoreDefensivesHp { get; set; }
-
-        [Setting]
-        [DefaultValue(true)]
-        public bool UseProvoke { get; set; }
 
         [Setting]
         [DefaultValue(true)]
@@ -56,9 +46,18 @@ namespace Magitek.Models.Roles
         [Setting]
         [DefaultValue(10)]
         public int ReprisalHealthPercent { get; set; }
+        #endregion
 
+        #region aggro
+        [Setting]
+        [DefaultValue(true)]
+        public bool UseProvoke { get; set; }
+        #endregion
+
+        #region interrupt
         [Setting]
         [DefaultValue(InterruptStrategy.AnyEnemy)]
         public InterruptStrategy Strategy { get; set; }
+        #endregion
     }
 }

--- a/Magitek/Models/Warrior/WarriorSettings.cs
+++ b/Magitek/Models/Warrior/WarriorSettings.cs
@@ -34,7 +34,24 @@ namespace Magitek.Models.Warrior
         public bool UseInnerRelease { get; set; }
         #endregion
 
-        #region Defensives
+
+        #region Heal
+        [Setting]
+        [DefaultValue(true)]
+        public bool UseHeal { get; set; }
+
+        [Setting]
+        [DefaultValue(1)]
+        public int MaxHealAtOnce { get; set; }
+
+        [Setting]
+        [DefaultValue(2)]
+        public int MaxHealUnderHp { get; set; }
+
+        [Setting]
+        [DefaultValue(50.0f)]
+        public float MoreHealHp { get; set; }
+
         [Setting]
         [DefaultValue(true)]
         public bool UseEquilibrium { get; set; }
@@ -42,15 +59,7 @@ namespace Magitek.Models.Warrior
         [Setting]
         [DefaultValue(60)]
         public int EquilibriumHealthPercent { get; set; }
-
-        [Setting]
-        [DefaultValue(true)]
-        public bool UseBloodWhetting { get; set; }
-
-        [Setting]
-        [DefaultValue(50)]
-        public int BloodWhettingHpPercentage { get; set; }
-
+        
         [Setting]
         [DefaultValue(false)]
         public bool UseThrillOfBattle { get; set; }
@@ -58,6 +67,17 @@ namespace Magitek.Models.Warrior
         [Setting]
         [DefaultValue(50)]
         public int ThrillOfBattleHpPercentage { get; set; }
+        #endregion
+
+
+        #region Defensives
+        [Setting]
+        [DefaultValue(true)]
+        public bool UseBloodWhetting { get; set; }
+
+        [Setting]
+        [DefaultValue(50)]
+        public int BloodWhettingHpPercentage { get; set; }
 
         [Setting]
         [DefaultValue(false)]

--- a/Magitek/Rotations/Bard.cs
+++ b/Magitek/Rotations/Bard.cs
@@ -4,7 +4,6 @@ using Magitek.Extensions;
 using Magitek.Logic;
 using Magitek.Logic.Bard;
 using Magitek.Logic.Roles;
-using Magitek.Models.Account;
 using Magitek.Models.Bard;
 using Magitek.Utilities;
 using BardRoutine = Magitek.Utilities.Routines.Bard;
@@ -22,9 +21,6 @@ namespace Magitek.Rotations
 
         public static async Task<bool> PreCombatBuff()
         {
-            if (Core.Me.IsCasting)
-                return true;
-
             if (await Casting.TrackSpellCast())
                 return true;
 
@@ -35,7 +31,6 @@ namespace Magitek.Rotations
             if (Core.Me.HasTarget && Core.Me.CurrentTarget.CanAttack)
                 return false;
 
-
             if (Globals.OnPvpMap)
                 return false;
 
@@ -44,14 +39,12 @@ namespace Magitek.Rotations
 
         public static async Task<bool> Pull()
         {
-            Utilities.Routines.Bard.RefreshVars();
+            BardRoutine.RefreshVars();
 
             if (BotManager.Current.IsAutonomous)
             {
                 if (Core.Me.HasTarget)
-                {
                     Movement.NavigateToUnitLos(Core.Me.CurrentTarget, 23);
-                }
             }
 
             if (await Casting.TrackSpellCast())
@@ -74,9 +67,6 @@ namespace Magitek.Rotations
 
         public static async Task<bool> Combat()
         {
-            if (Core.Me.IsCasting)
-                return true;
-
             if (await Casting.TrackSpellCast())
                 return true;
 
@@ -97,8 +87,7 @@ namespace Magitek.Rotations
                 }
             }
 
-            if (BardRoutine.GlobalCooldown.CountOGCDs() < 2 && Spells.HeavyShot.Cooldown.TotalMilliseconds >
-                650 + BaseSettings.Instance.UserLatencyOffset)
+            if (BardRoutine.GlobalCooldown.CanWeave())
             {
                 // Utility
                 if (await Utility.RepellingShot()) return true;

--- a/Magitek/Rotations/Dragoon.cs
+++ b/Magitek/Rotations/Dragoon.cs
@@ -109,7 +109,7 @@ namespace Magitek.Rotations
             if (await PhysicalDps.SecondWind(DragoonSettings.Instance)) return true;
             if (await PhysicalDps.Bloodbath(DragoonSettings.Instance)) return true;
 
-            if (DragoonRoutine.GlobalCooldown.CountOGCDs() < 2 && Spells.TrueThrust.Cooldown.TotalMilliseconds > 650 + BaseSettings.Instance.UserLatencyOffset)
+            if (DragoonRoutine.GlobalCooldown.CanWeave() && !DragoonRoutine.SingleWeaveJumpsList.Contains(Casting.LastSpell))
             {
                 //Buffs
                 if (await Buff.ForceDragonSight()) return true;
@@ -123,8 +123,15 @@ namespace Magitek.Rotations
                 //oGCD - Jump
                 if (await Aoe.WyrmwindThrust()) return true;
                 if (await Aoe.Geirskogul()) return true;
-                if (await Jumps.MirageDive()) return true;
-                if (await Jumps.Execute()) return true;
+                if (await Jumps.MirageDive()) return true; //DoubleWeave
+                
+                if (DragoonRoutine.GlobalCooldown.CanWeave(1))
+                {
+                    if (await Jumps.HighJump()) return true;  //SingleWeave
+                    if (await Jumps.DragonfireDive()) return true; //SingleWeave
+                    if (await Jumps.SpineshatterDive()) return true; //SingleWeave
+                    if (await Jumps.Stardiver()) return true; //SingleWeave
+                }
             }
 
             if (await Aoe.DraconianFury()) return true;

--- a/Magitek/Rotations/Gunbreaker.cs
+++ b/Magitek/Rotations/Gunbreaker.cs
@@ -76,7 +76,7 @@ namespace Magitek.Rotations
             if (await Tank.Interrupt(GunbreakerSettings.Instance)) return true;
             if (await Buff.RoyalGuard()) return true;
 
-            if (GunbreakerRoutine.GlobalCooldown.CountOGCDs() < 2 && Spells.KeenEdge.Cooldown.TotalMilliseconds > 650 + BaseSettings.Instance.UserLatencyOffset)
+            if (GunbreakerRoutine.GlobalCooldown.CanWeave())
             {
                 //Defensive Buff
                 if (await Defensive.Superbolide()) return true;
@@ -109,25 +109,22 @@ namespace Magitek.Rotations
             //Pull or get back aggro with LightningShot
             if (await SingleTarget.LightningShot()) return true;
 
-            //AOE
-            if (await Aoe.FatedCircle()) return true;
-            if (await Aoe.DemonSlaughter()) return true;
-            if (await Aoe.DemonSlice()) return true;
-
-            //Combo 2 - 1st step
-            if (await SingleTarget.GnashingFang()) return true;
-
             //Apply DOT / Burst
             if (await Aoe.DoubleDown()) return true;
             if (await SingleTarget.SonicBreak()) return true;
 
-            //Combo 2 - 2nd step
+            //Combo 2
             if (await SingleTarget.SavageClaw()) return true;
             if (await SingleTarget.WickedTalon()) return true;
+            if (await SingleTarget.GnashingFang()) return true;
 
             //Combo 3
             if (await SingleTarget.BurstStrike()) return true;
-            if (await SingleTarget.LightningShot()) return true;
+
+            //AOE
+            if (await Aoe.FatedCircle()) return true;
+            if (await Aoe.DemonSlaughter()) return true;
+            if (await Aoe.DemonSlice()) return true;
 
             //Combo 1 Filler
             if (await SingleTarget.SolidBarrel()) return true;

--- a/Magitek/Rotations/Machinist.cs
+++ b/Magitek/Rotations/Machinist.cs
@@ -7,6 +7,7 @@ using Magitek.Logic.Roles;
 using Magitek.Models.Machinist;
 using Magitek.Utilities;
 using MachinistRoutine = Magitek.Utilities.Routines.Machinist;
+using System;
 using System.Threading.Tasks;
 
 namespace Magitek.Rotations
@@ -15,7 +16,7 @@ namespace Magitek.Rotations
     {
         public static Task<bool> Rest()
         {
-            var needRest = Core.Me.CurrentHealthPercent < 75;
+            var needRest = Core.Me.CurrentHealthPercent < MachinistSettings.Instance.RestHealthPercent;
             return Task.FromResult(needRest);
         }
 
@@ -34,23 +35,20 @@ namespace Magitek.Rotations
             if (BotManager.Current.IsAutonomous)
             {
                 if (Core.Me.HasTarget)
-                {
                     Movement.NavigateToUnitLos(Core.Me.CurrentTarget, 23);
-                }
             }
 
             if (await Casting.TrackSpellCast())
                 return true;
 
             await Casting.CheckForSuccessfulCast();
+
             return await Combat();
         }
         public static async Task<bool> Heal()
         {
             if (Core.Me.IsMounted)
                 return true;
-
-
 
             if (await Casting.TrackSpellCast())
                 return true;
@@ -59,10 +57,12 @@ namespace Magitek.Rotations
 
             return await GambitLogic.Gambit();
         }
+
         public static Task<bool> CombatBuff()
         {
             return Task.FromResult(false);
         }
+
         public static async Task<bool> Combat()
         {
             if (BotManager.Current.IsAutonomous)
@@ -91,27 +91,51 @@ namespace Magitek.Rotations
                     return true;
             }
 
-            //Utility
-            if (await Utility.Tactician()) return true;
-            if (await PhysicalDps.ArmsLength(MachinistSettings.Instance)) return true;
-            if (await PhysicalDps.SecondWind(MachinistSettings.Instance)) return true;
-            if (await PhysicalDps.Interrupt(MachinistSettings.Instance)) return true;
-
-            if (MachinistRoutine.GlobalCooldown.CountOGCDs() < 2)
+            if (ActionResourceManager.Machinist.OverheatRemaining != TimeSpan.Zero)
             {
-                //Pets
-                if (await Pet.RookQueen()) return true;
-                if (await Pet.RookQueenOverdrive()) return true;
+                if (MachinistRoutine.GlobalCooldown.CanWeave(1)) {
+                    
+                    //Utility
+                    if (await PhysicalDps.ArmsLength(MachinistSettings.Instance)) return true;
+                    if (await PhysicalDps.Interrupt(MachinistSettings.Instance)) return true;
 
-                //Cooldowns
-                if (await Cooldowns.Wildfire()) return true;
-                if (await Cooldowns.Hypercharge()) return true;
-                if (await Cooldowns.Reassemble()) return true;
-                if (await Cooldowns.BarrelStabilizer()) return true;
+                    //Pets
+                    if (await Pet.RookQueen()) return true;
 
-                //oGCDs
-                if (await SingleTarget.GaussRound()) return true;
-                if (await MultiTarget.Ricochet()) return true;
+                    //Cooldowns
+                    if (await Cooldowns.BarrelStabilizer()) return true;
+
+                    //oGCDs
+                    if (await SingleTarget.GaussRound()) return true;
+                    if (await MultiTarget.Ricochet()) return true;
+
+                    //Cooldowns
+                    if (await Cooldowns.Reassemble()) return true;
+                }
+            } else
+            {
+                if (MachinistRoutine.GlobalCooldown.CanWeave()) {
+
+                    //Utility
+                    if (await Utility.Tactician()) return true;
+                    if (await PhysicalDps.ArmsLength(MachinistSettings.Instance)) return true;
+                    if (await PhysicalDps.SecondWind(MachinistSettings.Instance)) return true;
+                    if (await PhysicalDps.Interrupt(MachinistSettings.Instance)) return true;
+
+                    //Pets
+                    if (await Pet.RookQueen()) return true;
+                    if (await Pet.RookQueenOverdrive()) return true;
+
+                    //Cooldowns
+                    if (await Cooldowns.Wildfire()) return true;
+                    if (await Cooldowns.Hypercharge()) return true;
+                    if (await Cooldowns.Reassemble()) return true;
+                    if (await Cooldowns.BarrelStabilizer()) return true;
+
+                    //oGCDs
+                    if (await SingleTarget.GaussRound()) return true;
+                    if (await MultiTarget.Ricochet()) return true;
+                }
             }
 
             //GCDs - Top Hypercharge Priority

--- a/Magitek/Rotations/Warrior.cs
+++ b/Magitek/Rotations/Warrior.cs
@@ -4,7 +4,7 @@ using Magitek.Extensions;
 using Magitek.Logic;
 using Magitek.Logic.Roles;
 using Magitek.Logic.Warrior;
-using Magitek.Models.Account;
+using Healing = Magitek.Logic.Warrior.Heal;
 using Magitek.Models.Warrior;
 using Magitek.Utilities;
 using WarriorRoutine = Magitek.Utilities.Routines.Warrior;
@@ -69,16 +69,16 @@ namespace Magitek.Rotations
             if (await Tank.Interrupt(WarriorSettings.Instance)) return true;
             if (await Buff.Defiance()) return true;
 
-            if (WarriorRoutine.GlobalCooldown.CountOGCDs() < 2 && Spells.HeavySwing.Cooldown.TotalMilliseconds > 650 + BaseSettings.Instance.UserLatencyOffset)
+            if (WarriorRoutine.GlobalCooldown.CanWeave())
             {
                 //Defensive Buff
                 if (await Defensive.Holmgang()) return true;
-                if (await Buff.Equilibrium()) return true;
+                if (await Healing.Equilibrium()) return true;
+                if (await Healing.ThrillOfBattle()) return true;
                 if (await Defensive.Reprisal()) return true;
                 if (await Defensive.Rampart()) return true;
                 if (await Defensive.Vengeance()) return true;
                 if (await Defensive.ShakeItOff()) return true;
-                if (await Defensive.ThrillOfBattle()) return true;
                 if (await Defensive.BloodWhetting()) return true;
                 if (await Buff.NascentFlash()) return true;
 

--- a/Magitek/Utilities/Auras.cs
+++ b/Magitek/Utilities/Auras.cs
@@ -289,7 +289,9 @@ namespace Magitek.Utilities
             PowerSurge = 2720,
             ChaoticSpring = 2719,
             ChaosThrust = 118,
-            LanceCharge = 1864;
+            LanceCharge = 1864,
+            Equilibrium = 2681
+            ;
 
         private const int
             Invincibility0 = 981,

--- a/Magitek/Utilities/Routines/Dragoon.cs
+++ b/Magitek/Utilities/Routines/Dragoon.cs
@@ -45,6 +45,14 @@ namespace Magitek.Utilities.Routines
             Spells.Stardiver
         };
 
+        public static List<SpellData> SingleWeaveJumpsList = new List<SpellData>()
+        {
+            HighJump,
+            Spells.SpineshatterDive,
+            Spells.DragonfireDive,
+            Spells.Stardiver
+        };
+
         public static int GetWeight(Character c)
         {
             switch (c.CurrentJob)

--- a/Magitek/Utilities/Routines/Gunbreaker.cs
+++ b/Magitek/Utilities/Routines/Gunbreaker.cs
@@ -36,17 +36,6 @@ namespace Magitek.Utilities.Routines
         public static int RequiredCartridgeForBurstStrike => 1;
         public static int RequiredCartridgeForFatedCircle => 1;
 
-        public static bool ToggleAndSpellCheck(bool Toggle, SpellData Spell)
-        {
-            if (!Toggle)
-                return false;
-
-            if (!ActionManager.HasSpell(Spell.Id))
-                return false;
-
-            return true;
-        }
-
         public static bool IsAurasForComboActive()
         {
             return Core.Me.HasAura(Auras.ReadytoRip) || Core.Me.HasAura(Auras.ReadytoTear) || Core.Me.HasAura(Auras.ReadytoGouge) || Core.Me.HasAura(Auras.ReadytoBlast);

--- a/Magitek/Utilities/Routines/Machinist.cs
+++ b/Magitek/Utilities/Routines/Machinist.cs
@@ -14,33 +14,6 @@ namespace Magitek.Utilities.Routines
     {
         public static WeaveWindow GlobalCooldown = new WeaveWindow(ClassJobType.Machinist, Spells.SplitShot, new List<SpellData>() { Spells.Flamethrower });
 
-        public static bool IsInWeaveingWindow => ActionResourceManager.Machinist.OverheatRemaining != TimeSpan.Zero
-                                                ? GlobalCooldown.CountOGCDs() < 1 && HeatedSplitShot.Cooldown != TimeSpan.Zero
-                                                : GlobalCooldown.CountOGCDs() < 2 && HeatedSplitShot.Cooldown != TimeSpan.Zero
-                                                                            && HeatedSplitShot.Cooldown.TotalMilliseconds > Globals.AnimationLockMs + 50 + MachinistSettings.Instance.UserLatencyOffset;
-
-
-        /*
-        // Export IsInWeaveingWindow in a method to help for debug if necessary
-        public static bool IsInWeaveingWindow => IsInWeaveingWindowMethod();
-        public static bool IsInWeaveingWindowMethod()
-        {
-            var heatedSplitShotCooldown = HeatedSplitShot.Cooldown;
-            var heatedSplitShotCooldownTotalMilliseconds = HeatedSplitShot.Cooldown.TotalMilliseconds;
-            var currentWeavingCounter = Weaving.GetCurrentWeavingCounter();
-
-            
-            //Logger.WriteInfo($@"heatedSplitShotCooldownTotalMilliseconds: {heatedSplitShotCooldownTotalMilliseconds}");
-            //Logger.WriteInfo($@"currentWeavingCounter: {currentWeavingCounter}");
-
-            return ActionResourceManager.Machinist.OverheatRemaining != TimeSpan.Zero
-                                                ? currentWeavingCounter < 1 && heatedSplitShotCooldown != TimeSpan.Zero
-                                                : currentWeavingCounter < 2 && heatedSplitShotCooldown != TimeSpan.Zero
-                                                                            && heatedSplitShotCooldownTotalMilliseconds > AnimationLock + 50 + MachinistSettings.Instance.UserLatencyOffset;
-        }
-        */
-
-        //skill upgrades
         public static SpellData HeatedSplitShot => Core.Me.ClassLevel < 54
                                                     ? Spells.SplitShot
                                                     : Spells.HeatedSplitShot;
@@ -67,17 +40,6 @@ namespace Magitek.Utilities.Routines
         public static SpellData Scattergun => Core.Me.ClassLevel < 82
                                                     ? Spells.SpreadShot
                                                     : Spells.Scattergun;
-
-        public static bool ToggleAndSpellCheck(bool Toggle, SpellData Spell)
-        {
-            if (!Toggle)
-                return false;
-
-            if (!ActionManager.HasSpell(Spell.Id))
-                return false;
-
-            return true;
-        }
 
         public static bool CanContinueComboAfter(SpellData LastSpellExecuted)
         {
@@ -163,6 +125,5 @@ namespace Magitek.Utilities.Routines
             Logger.WriteInfo($@"Damage Increase: {dmgIncrease}");
             return dmgIncrease >= (1 + (double)neededDmgIncrease / 100);
         }
-
     }
 }

--- a/Magitek/Utilities/Routines/Warrior.cs
+++ b/Magitek/Utilities/Routines/Warrior.cs
@@ -26,18 +26,6 @@ namespace Magitek.Utilities.Routines
                                             ? Spells.RawIntuition
                                             : Spells.Bloodwhetting;
 
-
-        public static bool ToggleAndSpellCheck(bool Toggle, SpellData Spell)
-        {
-            if (!Toggle)
-                return false;
-
-            if (!ActionManager.HasSpell(Spell.Id))
-                return false;
-
-            return true;
-        }
-
         public static bool CanContinueComboAfter(SpellData LastSpellExecuted)
         {
             if (ActionManager.ComboTimeLeft <= 0)
@@ -56,6 +44,12 @@ namespace Magitek.Utilities.Routines
             Auras.Bloodwhetting,
             Auras.Vengeance,
             Auras.Holmgang,
+            Auras.ThrillOfBattle
+        };
+
+        public static readonly List<uint> Heal = new List<uint>()
+        {
+            Auras.Equilibrium,
             Auras.ThrillOfBattle
         };
     }

--- a/Magitek/Views/UserControls/Gunbreaker/Combat.xaml
+++ b/Magitek/Views/UserControls/Gunbreaker/Combat.xaml
@@ -99,12 +99,16 @@
                         <controls:Numeric Margin="0,3" MaxValue="50" MinValue="1" Value="{Binding GunbreakerSettings.DemonSliceSlaughterEnemies, Mode=TwoWay}" />
                         <TextBlock Style="{DynamicResource TextBlockDefault}" Text=" Enemies" />
                     </StackPanel>
-                </StackPanel>
 
-                <StackPanel Grid.Row="2" Margin="5">
                     <StackPanel Orientation="Horizontal">
-                        <TextBlock Style="{DynamicResource TextBlockDefault}" Text="Fated Circle When There Are At Least " />
-                        <controls:Numeric Margin="0,3" MaxValue="50" MinValue="1" Value="{Binding GunbreakerSettings.FatedCircleEnemies, Mode=TwoWay}" />
+                        <TextBlock Style="{DynamicResource TextBlockDefault}" Text="Prioritize Fated Circle over Gnashing Fang from " />
+                        <controls:Numeric Margin="0,3" MaxValue="50" MinValue="1" Value="{Binding GunbreakerSettings.PrioritizeFatedCircleOverGnashingFangEnemies, Mode=TwoWay}" />
+                        <TextBlock Style="{DynamicResource TextBlockDefault}" Text=" Enemies" />
+                    </StackPanel>
+
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Style="{DynamicResource TextBlockDefault}" Text="Prioritize Fated Circle over Burst Strike from " />
+                        <controls:Numeric Margin="0,3" MaxValue="50" MinValue="1" Value="{Binding GunbreakerSettings.PrioritizeFatedCircleOverBurstStrikeEnemies, Mode=TwoWay}" />
                         <TextBlock Style="{DynamicResource TextBlockDefault}" Text=" Enemies" />
                     </StackPanel>
                 </StackPanel>

--- a/Magitek/Views/UserControls/Gunbreaker/Defensives.xaml
+++ b/Magitek/Views/UserControls/Gunbreaker/Defensives.xaml
@@ -58,7 +58,7 @@
                         <RowDefinition />
                     </Grid.RowDefinitions>
 
-                    <CheckBox Grid.Row="0" Grid.Column="0" Content="Heart of Corundum" IsChecked="{Binding GunbreakerSettings.UseHeartofCorundum, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <CheckBox Grid.Row="0" Grid.Column="0" Content="Heart of Corundum / Heart of Stone  " IsChecked="{Binding GunbreakerSettings.UseHeartofCorundum, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                     <controls:Numeric Grid.Row="0" Grid.Column="1" MaxValue="100" MinValue="1" Value="{Binding GunbreakerSettings.HeartofCorundumHealthPercent, Mode=TwoWay}" />
                     <TextBlock Grid.Row="0" Grid.Column="2" Style="{DynamicResource TextBlockDefault}" Text=" Health Percent" />
 
@@ -82,10 +82,9 @@
                     <controls:Numeric Grid.Row="5" Grid.Column="1" Margin="0,3,0,0" MaxValue="100" MinValue="1" Value="{Binding GunbreakerSettings.NebulaHealthPercent, Mode=TwoWay}" />
                     <TextBlock Grid.Row="5" Grid.Column="2" Style="{DynamicResource TextBlockDefault}" Text=" Health Percent" />
 
-                    <CheckBox Grid.Row="6" Grid.Column="0" Content="Aurora" IsChecked="{Binding GunbreakerSettings.UseAurora, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                    <controls:Numeric Grid.Row="6" Grid.Column="1" Margin="0,3,0,0" MaxValue="100" MinValue="1" Value="{Binding GunbreakerSettings.UseAuroraSelfHealthPercent, Mode=TwoWay}" />
+                    <CheckBox Grid.Row="6" Grid.Column="0" Content="Super Bolide" IsChecked="{Binding GunbreakerSettings.UseSuperbolide, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <controls:Numeric Grid.Row="6" Grid.Column="1" Margin="0,3,0,0" MaxValue="100" MinValue="1" Value="{Binding GunbreakerSettings.SuperbolideHealthPercent, Mode=TwoWay}" />
                     <TextBlock Grid.Row="6" Grid.Column="2" Style="{DynamicResource TextBlockDefault}" Text=" Health Percent" />
-
                 </Grid>
             </StackPanel>
         </controls:SettingsBlock>

--- a/Magitek/Views/UserControls/Warrior/Buff.xaml
+++ b/Magitek/Views/UserControls/Warrior/Buff.xaml
@@ -25,22 +25,6 @@
         <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
             <StackPanel Margin="5">
                 <StackPanel Orientation="Horizontal">
-                    <CheckBox Content="Use Thrill Of Battle When Under " IsChecked="{Binding WarriorSettings.UseThrillOfBattle, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                    <controls:Numeric MaxValue="100" MinValue="1" Value="{Binding WarriorSettings.ThrillOfBattleHpPercentage, Mode=TwoWay}" />
-                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text=" Health Percent" />
-                </StackPanel>
-
-                <StackPanel Orientation="Horizontal">
-                    <CheckBox Content="Use Equilibrium When Under" IsChecked="{Binding WarriorSettings.UseEquilibrium, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                    <controls:Numeric MaxValue="100" MinValue="1" Value="{Binding WarriorSettings.EquilibriumHealthPercent, Mode=TwoWay}" />
-                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text=" Health Percent(WIP)" />
-                </StackPanel>
-            </StackPanel>
-        </controls:SettingsBlock>
-
-        <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
-            <StackPanel Margin="5">
-                <StackPanel Orientation="Horizontal">
                     <CheckBox Content="Use Infuriate At " IsChecked="{Binding WarriorSettings.UseInfuriate, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                     <controls:Numeric Increment="10" MaxValue="100" MinValue="10" Value="{Binding WarriorSettings.UseInfuriateAtBeastGauge, Mode=TwoWay}" />
                     <TextBlock Style="{DynamicResource TextBlockDefault}" Text=" Or Under Beast Gauge" />

--- a/Magitek/Views/UserControls/Warrior/Defensives.xaml
+++ b/Magitek/Views/UserControls/Warrior/Defensives.xaml
@@ -95,15 +95,6 @@
                                       Value="{Binding WarriorSettings.RampartHpPercentage, Mode=TwoWay}" />
                     <TextBlock Grid.Row="3" Grid.Column="2" Style="{DynamicResource TextBlockDefault}" Text=" Health Percent" />
 
-                    <CheckBox Grid.Row="4" Grid.Column="0" Content="Thrill Of Battle(WIP)" IsChecked="{Binding WarriorSettings.UseThrillOfBattle, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                    <controls:Numeric Grid.Row="4"
-                                      Grid.Column="1"
-                                      Margin="0,3"
-                                      MaxValue="100"
-                                      MinValue="1"
-                                      Value="{Binding WarriorSettings.ThrillOfBattleHpPercentage, Mode=TwoWay}" />
-                    <TextBlock Grid.Row="4" Grid.Column="2" Style="{DynamicResource TextBlockDefault}" Text=" Health Percent" />
-
                     <CheckBox Grid.Row="5" Grid.Column="0" Content="Reprisal" IsChecked="{Binding WarriorSettings.UseReprisal, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                     <controls:Numeric Grid.Row="5"
                                       Grid.Column="1"

--- a/Magitek/Views/UserControls/Warrior/Healing.xaml
+++ b/Magitek/Views/UserControls/Warrior/Healing.xaml
@@ -1,0 +1,66 @@
+﻿<UserControl x:Class="Magitek.Views.UserControls.Warrior.Healing"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:Magitek.Controls"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:viewModels="clr-namespace:Magitek.ViewModels"
+             d:DesignHeight="400"
+             d:DesignWidth="500"
+             mc:Ignorable="d">
+
+    <UserControl.DataContext>
+        <Binding Source="{x:Static viewModels:BaseSettings.Instance}" />
+    </UserControl.DataContext>
+
+    <UserControl.Resources>
+        <ResourceDictionary Source="/Magitek;component/Styles/Magitek.xaml" />
+    </UserControl.Resources>
+
+    <StackPanel Margin="10">
+        <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
+            <StackPanel Margin="0,10">
+
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="Only Use " />
+                    <controls:Numeric Margin="0,3" MaxValue="100" MinValue="1" Value="{Binding WarriorSettings.MaxHealAtOnce, Mode=TwoWay}" />
+                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text=" Healing Buffs At The Same Time" />
+                </StackPanel>
+
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="Unless You Are Lower Than " />
+                    <controls:Numeric Margin="0,3" MaxValue="100" MinValue="1" Value="{Binding WarriorSettings.MoreHealHp, Mode=TwoWay}" />
+                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text=" Health Percent" />
+                </StackPanel>
+
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="At Which Point, Use A Maximum Of  " />
+                    <controls:Numeric Margin="0,3" MaxValue="100" MinValue="1" Value="{Binding WarriorSettings.MaxHealUnderHp, Mode=TwoWay}" />
+                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text=" Healing Buffs At The Same Time" />
+                </StackPanel>
+
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition />
+                        <RowDefinition />
+                    </Grid.RowDefinitions>
+
+                    <CheckBox Grid.Row="0" Grid.Column="0" Content="Use Thrill Of Battle When Under " IsChecked="{Binding WarriorSettings.UseThrillOfBattle, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <controls:Numeric Grid.Row="0" Grid.Column="1" MaxValue="100" MinValue="1" Value="{Binding WarriorSettings.ThrillOfBattleHpPercentage, Mode=TwoWay}" />
+                    <TextBlock Grid.Row="0" Grid.Column="2" Style="{DynamicResource TextBlockDefault}" Text=" Health Percent" />
+
+                    <CheckBox Grid.Row="1" Grid.Column="0" Content="Use Equilibrium When Under" IsChecked="{Binding WarriorSettings.UseEquilibrium, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <controls:Numeric Grid.Row="1" Grid.Column="1" MaxValue="100" MinValue="1" Value="{Binding WarriorSettings.EquilibriumHealthPercent, Mode=TwoWay}" />
+                    <TextBlock Grid.Row="1" Grid.Column="2" Style="{DynamicResource TextBlockDefault}" Text=" Health Percent" />
+                </Grid>
+            </StackPanel>
+        </controls:SettingsBlock>
+
+    </StackPanel>
+
+</UserControl>

--- a/Magitek/Views/UserControls/Warrior/Healing.xaml.cs
+++ b/Magitek/Views/UserControls/Warrior/Healing.xaml.cs
@@ -1,0 +1,15 @@
+﻿using System.Windows.Controls;
+
+namespace Magitek.Views.UserControls.Warrior
+{
+    /// <summary>
+    /// Interaction logic for Healing.xaml
+    /// </summary>
+    public partial class Healing : UserControl
+    {
+        public Healing()
+        {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
- Migrate to new OGCDManager to manage Weaving
- Rework Single and Double weaving
- Remove check on Existing spell
- Cleaning code

WAR:
- Migrate to new OGCDManager to manage Weaving
- Remove check on Existing spell
- Remove ThrillOfBattle from Defensive Group
- Group ThrillOfBattle and Equilibrium in same group called "Heal"
- Let the ability to define how many heal spell can be executed at the same time (UI + Toggle)
- Cleaning code

GNB
- Migrate to new OGCDManager to manage Weaving
- Remove check on Existing spell
- Delay NoMercy at the end of GCD
- Fix AOE Rotation to use Ammo properly and NoMercy Buff properly
- Add new settings in UI to determine how to prioritize FatedCircle over BurstStrike and GnashingFang
- Add Superbolide in UI
- Remove Aurora from Defensive UI
- Cleaning code

DRG:
- Migrate to new OGCDManager to manage Weaving
- Remove check on Existing spell
- Improve Jump Management to prevent Double Weave on some jumps

BRD:
- Migrate to new OGCDManager to manage Weaving
- Remove some check on Existing spell