### PR TITLE
Initial DRK update for 6.0 expansion.

### DIFF
--- a/Magitek/Logic/DarkKnight/Aoe.cs
+++ b/Magitek/Logic/DarkKnight/Aoe.cs
@@ -13,10 +13,14 @@ namespace Magitek.Logic.DarkKnight
     {
         public static async Task<bool> AbyssalDrain()
         {
+            if (!DarkKnightSettings.Instance.UseAoe)
+                return false;
+
             if (!DarkKnightSettings.Instance.UseAbyssalDrain)
                 return false;
 
-            if (Combat.Enemies.Count(r => r.Distance(Core.Me.CurrentTarget) <= 5) < DarkKnightSettings.Instance.AbyssalDrainEnemies)
+            var enemyCount = Combat.Enemies.Count(r => r.Distance(Core.Me.CurrentTarget) <= 5);
+            if (enemyCount < DarkKnightSettings.Instance.AbyssalDrainEnemies)
                 return false;
 
             return await Spells.AbyssalDrain.Cast(Core.Me.CurrentTarget);
@@ -24,31 +28,35 @@ namespace Magitek.Logic.DarkKnight
 
         public static async Task<bool> SaltedEarth()
         {
+            if (!DarkKnightSettings.Instance.UseAoe)
+                return false;
+
             if (!DarkKnightSettings.Instance.UseSaltedEarth)
                 return false;
 
             if (MovementManager.IsMoving)
                 return false;
 
-            if (Combat.Enemies.Count(r => r.Distance(Core.Me.CurrentTarget) <= 5) < DarkKnightSettings.Instance.SaltedEarthEnemies)
-
+            var enemyCount = Combat.Enemies.Count(r => r.Distance(Core.Me) <= 5);
+            if (enemyCount < DarkKnightSettings.Instance.SaltedEarthEnemies)
                 return false;
 
-            return await Spells.SaltedEarth.Cast(Core.Me.CurrentTarget);
+            return await Spells.SaltedEarth.Cast(Core.Me);
         }
 
         public static async Task<bool> Unleash()
         {
-            if (!DarkKnightSettings.Instance.UseUnleash)
+            if (!DarkKnightSettings.Instance.UseAoe)
                 return false;
 
-            if (!DarkKnightSettings.Instance.UseAoe)
+            if (!DarkKnightSettings.Instance.UseUnleash)
                 return false;
 
             if (Core.Me.HasAura(Auras.Delirium))
                 return false;
 
-            if (Combat.Enemies.Count(r => r.Distance(Core.Me) <= 5 + r.CombatReach) < DarkKnightSettings.Instance.UnleashEnemies)
+            var enemyCount = Combat.Enemies.Count(r => r.Distance(Core.Me) <= 5 + r.CombatReach);
+            if (enemyCount < DarkKnightSettings.Instance.UnleashEnemies)
                 return false;
 
             return await Spells.Unleash.Cast(Core.Me);
@@ -56,18 +64,17 @@ namespace Magitek.Logic.DarkKnight
 
         public static async Task<bool> StalwartSoul()
         {
-            if (ActionManager.LastSpell != Spells.Unleash)
+            if (!DarkKnightSettings.Instance.UseAoe)
                 return false;
 
-
-            if (!DarkKnightSettings.Instance.UseAoe)
+            if (ActionManager.LastSpell != Spells.Unleash)
                 return false;
 
             if (Core.Me.HasAura(Auras.Delirium))
                 return false;
 
-            if (Combat.Enemies.Count(r => r.Distance(Core.Me) <= 5 + r.CombatReach) < DarkKnightSettings.Instance.UnleashEnemies)
-
+            var enemyCount = (Combat.Enemies.Count(r => r.Distance(Core.Me) <= 5 + r.CombatReach));
+            if (enemyCount < DarkKnightSettings.Instance.UnleashEnemies)
                 return false;
 
             return await Spells.StalwartSoul.Cast(Core.Me);
@@ -75,40 +82,36 @@ namespace Magitek.Logic.DarkKnight
 
         public static async Task<bool> Quietus()
         {
-            if (!DarkKnightSettings.Instance.UseQuietus)
-                return false;
 
             if (!DarkKnightSettings.Instance.UseAoe)
                 return false;
 
-            if (Combat.Enemies.Count(r => r.Distance(Core.Me) <= 5 + r.CombatReach) < DarkKnightSettings.Instance.QuietusEnemies)
+            if (!DarkKnightSettings.Instance.UseQuietus)
                 return false;
 
-            if (ActionResourceManager.DarkKnight.BlackBlood >= 50 || Core.Me.HasAura(Auras.Delirium))
-                return await Spells.Quietus.Cast(Core.Me);
+            var enemyCount = Combat.Enemies.Count(r => r.Distance(Core.Me) <= 5 + r.CombatReach);
+            if (enemyCount < DarkKnightSettings.Instance.QuietusEnemies)
+                return false;
 
-            return false;
+            return await Spells.Quietus.Cast(Core.Me);
         }
 
         public static async Task<bool> FloodofDarknessShadow()
         {
-            if (!DarkKnightSettings.Instance.UseFloodDarknessShadow)
-                return false;
-
             if (!DarkKnightSettings.Instance.UseAoe)
                 return false;
 
-            if (Combat.Enemies.Count(r => r.Distance(Core.Me.CurrentTarget) <= 10 + r.CombatReach) < DarkKnightSettings.Instance.FloodEnemies)
+            if (!DarkKnightSettings.Instance.UseFloodDarknessShadow)
+                return false;
 
+            var enemyCount = Combat.Enemies.Count(r => r.Distance(Core.Me.CurrentTarget) <= 10 + r.CombatReach);
+            if (enemyCount < DarkKnightSettings.Instance.FloodEnemies)
                 return false;
 
             if (Core.Me.CurrentMana < 6000 && DarkKnightSettings.Instance.UseTheBlackestNight)
                 return false;
 
             if (Core.Me.CurrentMana < DarkKnightSettings.Instance.SaveXMana + 3000)
-                return false;
-
-            if (DarkKnightSettings.Instance.UseTheBlackestNight && Core.Me.CurrentMana < 6000)
                 return false;
 
             return await Spells.FloodofDarkness.Cast(Core.Me.CurrentTarget);

--- a/Magitek/Logic/DarkKnight/SingleTarget.cs
+++ b/Magitek/Logic/DarkKnight/SingleTarget.cs
@@ -47,10 +47,8 @@ namespace Magitek.Logic.DarkKnight
             if (!DarkKnightSettings.Instance.UseBloodspiller)
                 return false;
 
-            if (ActionResourceManager.DarkKnight.BlackBlood >= 50 || Core.Me.HasAura(Auras.Delirium))
-                return await Spells.Bloodspiller.Cast(Core.Me.CurrentTarget);
+            return await Spells.Bloodspiller.Cast(Core.Me.CurrentTarget);
 
-            return false;
         }
 
         public static async Task<bool> Unmend()
@@ -58,18 +56,19 @@ namespace Magitek.Logic.DarkKnight
             if (Globals.OnPvpMap)
                 return false;
 
-            if (Core.Me.HasAura(Auras.Delirium))
+            if (BotManager.Current.IsAutonomous)
                 return false;
 
             if (!DarkKnightSettings.Instance.UnmendToPullAggro)
                 return false;
 
-            if (BotManager.Current.IsAutonomous)
+            if (Core.Me.HasAura(Auras.Delirium))
                 return false;
 
-            var unmendTarget = Combat.Enemies.FirstOrDefault(r => r.Distance(Core.Me) >= Core.Me.CombatReach + r.CombatReach &&
-                                                                  r.Distance(Core.Me) <= 15 + r.CombatReach &&
-                                                                  r.TargetGameObject != Core.Me);
+            var unmendTarget = Combat.Enemies.FirstOrDefault(r =>
+                r.Distance(Core.Me) >= Core.Me.CombatReach + r.CombatReach
+                && r.Distance(Core.Me) <= 20 + r.CombatReach
+                && !r.TargetGameObject.IsMe);
 
             if (unmendTarget == null)
                 return false;
@@ -82,6 +81,14 @@ namespace Magitek.Logic.DarkKnight
 
             Logger.Write($@"Unmend On {unmendTarget.Name} To Pull Aggro");
             return true;
+        }
+
+        public static async Task<bool> Shadowbringer()
+        {
+            if (!DarkKnightSettings.Instance.UseShadowbringer)
+                return false;
+
+            return await Spells.Shadowbringer.Cast(Core.Me.CurrentTarget);
         }
 
         public static async Task<bool> EdgeofDarknessShadow()
@@ -115,17 +122,7 @@ namespace Magitek.Logic.DarkKnight
             if (!DarkKnightSettings.Instance.UsePlunge)
                 return false;
 
-            Logger.Write($@"We are about to Plunge, The toggle was {DarkKnightSettings.Instance.UsePlunge}");
-
             return await Spells.Plunge.Cast(Core.Me.CurrentTarget);
-        }
-
-        public static async Task<bool> Reprisal()
-        {
-            if (!DarkKnightSettings.Instance.UseReprisal)
-                return false;
-
-            return await Spells.Reprisal.Cast(Core.Me.CurrentTarget);
         }
     }
 }

--- a/Magitek/Models/DarkKnight/DarkKnightSettings.cs
+++ b/Magitek/Models/DarkKnight/DarkKnightSettings.cs
@@ -12,6 +12,17 @@ namespace Magitek.Models.DarkKnight
 
         public static DarkKnightSettings Instance { get; set; } = new DarkKnightSettings();
 
+        // Autonomous
+        #region Autonomous
+        [Setting]
+        [DefaultValue(3.0f)]
+        public float AutonomousPullDistance { get; set; }
+
+        [Setting]
+        [DefaultValue(3.0f)]
+        public float AutonomousCombatDistance { get; set; }
+        #endregion
+
         //General
         #region General
         [Setting]
@@ -38,6 +49,26 @@ namespace Magitek.Models.DarkKnight
         public bool Grit { get; set; }
 
         [Setting]
+        [DefaultValue(true)]
+        public bool UseOblation { get; set; }
+
+        [Setting]
+        [DefaultValue(false)]
+        public bool UseOblationOnTanks { get; set; }
+
+        [Setting]
+        [DefaultValue(false)]
+        public bool UseOblationOnHealers { get; set; }
+
+        [Setting]
+        [DefaultValue(false)]
+        public bool UseOblationOnDPS { get; set; }
+
+        [Setting]
+        [DefaultValue(60.0f)]
+        public float UseOblationAtHpPercent { get; set; }
+
+        [Setting]
         [DefaultValue(false)]
         public bool UseTheBlackestNight { get; set; }
 
@@ -46,7 +77,7 @@ namespace Magitek.Models.DarkKnight
         public float TheBlackestNightHealth { get; set; }
 
         [Setting]
-        [DefaultValue(false)]
+        [DefaultValue(true)]
         public bool UseDarkMind { get; set; }
 
         [Setting]
@@ -54,7 +85,7 @@ namespace Magitek.Models.DarkKnight
         public float DarkMindHealth { get; set; }
 
         [Setting]
-        [DefaultValue(false)]
+        [DefaultValue(true)]
         public bool UseDarkMissionary { get; set; }
 
         [Setting]
@@ -62,7 +93,7 @@ namespace Magitek.Models.DarkKnight
         public float DarkMissionaryHealth { get; set; }
 
         [Setting]
-        [DefaultValue(false)]
+        [DefaultValue(true)]
         public bool UseShadowWall { get; set; }
 
         [Setting]
@@ -70,11 +101,11 @@ namespace Magitek.Models.DarkKnight
         public float ShadowWallHealth { get; set; }
 
         [Setting]
-        [DefaultValue(false)]
+        [DefaultValue(true)]
         public bool UseLivingDead { get; set; }
 
         [Setting]
-        [DefaultValue(15.0f)]
+        [DefaultValue(10.0f)]
         public float LivingDeadHealth { get; set; }
         #endregion
 
@@ -98,6 +129,10 @@ namespace Magitek.Models.DarkKnight
         [Setting]
         [DefaultValue(false)]
         public bool UsePlunge { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
+        public bool UseShadowbringer { get; set; }
 
         [Setting]
         [DefaultValue(true)]
@@ -154,6 +189,5 @@ namespace Magitek.Models.DarkKnight
         [DefaultValue(2)]
         public int FloodEnemies { get; set; }
         #endregion
-
     }
 }

--- a/Magitek/Rotations/DarkKnight.cs
+++ b/Magitek/Rotations/DarkKnight.cs
@@ -1,34 +1,21 @@
 ﻿using ff14bot;
 using ff14bot.Managers;
-using Magitek.Extensions;
 using Magitek.Logic;
 using Magitek.Logic.DarkKnight;
 using Magitek.Logic.Roles;
 using Magitek.Models.Account;
 using Magitek.Models.DarkKnight;
 using Magitek.Utilities;
-using DarkKnightRoutine = Magitek.Utilities.Routines.DarkKnight;
 using System.Threading.Tasks;
+using DarkKnightRoutine = Magitek.Utilities.Routines.DarkKnight;
 
 namespace Magitek.Rotations
 {
     public static class DarkKnight
     {
-        public static Task<bool> Rest()
-        {
-            return Task.FromResult(false);
-        }
-
         public static async Task<bool> PreCombatBuff()
         {
-
-
-            if (Core.Me.IsCasting)
-                return true;
-
             await Casting.CheckForSuccessfulCast();
-
-            Utilities.Routines.DarkKnight.PullUnleash = 0;
             return await Buff.Grit();
         }
 
@@ -36,49 +23,49 @@ namespace Magitek.Rotations
         {
             if (BotManager.Current.IsAutonomous)
             {
-                Movement.NavigateToUnitLos(Core.Me.CurrentTarget, 3);
+                Movement.NavigateToUnitLos(Core.Me.CurrentTarget,
+                    DarkKnightSettings.Instance.AutonomousPullDistance);
             }
 
             return await Combat();
         }
         public static async Task<bool> Heal()
         {
-            if (Core.Me.IsMounted)
+            if (await GambitLogic.Gambit())
                 return true;
 
-            if (await GambitLogic.Gambit()) return true;
-            if (await Casting.TrackSpellCast()) return true;
+            if (await Casting.TrackSpellCast())
+                return true;
+
             await Casting.CheckForSuccessfulCast();
 
             return false;
         }
-        public static Task<bool> CombatBuff()
-        {
-            return Task.FromResult(false);
-        }
+
         public static async Task<bool> Combat()
         {
-            if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
-                return false;
-
-            if (await CustomOpenerLogic.Opener()) return true;
-
-            //if (await Defensive.ExecuteTankBusters()) return true;
+            if (await CustomOpenerLogic.Opener())
+                return true;
 
             if (BotManager.Current.IsAutonomous)
             {
-                Movement.NavigateToUnitLos(Core.Me.CurrentTarget, 3 + Core.Me.CurrentTarget.CombatReach);
+                Movement.NavigateToUnitLos(Core.Me.CurrentTarget,
+                    DarkKnightSettings.Instance.AutonomousCombatDistance + Core.Me.CurrentTarget.CombatReach);
             }
 
-            if (await Buff.Grit()) return true;
-            if (await Tank.Interrupt(DarkKnightSettings.Instance)) return true;
+            if (await Buff.Grit())
+                return true;
 
-            if (DarkKnightRoutine.GlobalCooldown.CountOGCDs() < 2 && Spells.HardSlash.Cooldown.TotalMilliseconds > 650 + BaseSettings.Instance.UserLatencyOffset)
+            if (await Tank.Interrupt(DarkKnightSettings.Instance))
+                return true;
+
+            if (DarkKnightRoutine.GlobalCooldown.CountOGCDs() < 2
+                && Spells.HardSlash.Cooldown.TotalMilliseconds > 650 + BaseSettings.Instance.UserLatencyOffset)
             {
                 if (await Tank.Provoke(DarkKnightSettings.Instance)) return true;
                 if (await Defensive.Execute()) return true;
-                if (await Defensive.TheBlackestNight()) return true;
-                if (await SingleTarget.Reprisal()) return true;
+                if (await Defensive.Oblation(true)) return true;
+                if (await Defensive.Reprisal()) return true;
                 if (await SingleTarget.CarveAndSpit()) return true;
                 if (await Aoe.SaltedEarth()) return true;
                 if (await Aoe.AbyssalDrain()) return true;
@@ -88,6 +75,7 @@ namespace Magitek.Rotations
                 if (await Buff.Delirium()) return true;
                 if (await Buff.BloodWeapon()) return true;
                 if (await Buff.LivingShadow()) return true;
+                if (await SingleTarget.Shadowbringer()) return true;
             }
 
             if (await SingleTarget.Unmend()) return true;
@@ -100,9 +88,8 @@ namespace Magitek.Rotations
             if (await SingleTarget.SyphonStrike()) return true;
             return await SingleTarget.HardSlash();
         }
-        public static Task<bool> PvP()
-        {
-            return Task.FromResult(false);
-        }
+        public static Task<bool> PvP() => Task.FromResult(false);
+        public static Task<bool> Rest() => Task.FromResult(false);
+        public static Task<bool> CombatBuff() => Task.FromResult(false);
     }
 }

--- a/Magitek/Utilities/Auras.cs
+++ b/Magitek/Utilities/Auras.cs
@@ -290,8 +290,8 @@ namespace Magitek.Utilities
             ChaoticSpring = 2719,
             ChaosThrust = 118,
             LanceCharge = 1864,
-            Equilibrium = 2681
-            ;
+            Equilibrium = 2681,
+            Oblation = 2682;
 
         private const int
             Invincibility0 = 981,

--- a/Magitek/Utilities/Routines/DarkKnight.cs
+++ b/Magitek/Utilities/Routines/DarkKnight.cs
@@ -1,24 +1,22 @@
 using ff14bot.Enums;
-using System;
 using System.Collections.Generic;
 
 namespace Magitek.Utilities.Routines
 {
     internal static class DarkKnight
     {
-        public static WeaveWindow GlobalCooldown = new WeaveWindow(ClassJobType.DarkKnight, Spells.HardSlash);
-
-        public static int PullUnleash;
+        public static WeaveWindow GlobalCooldown
+            = new WeaveWindow(ClassJobType.DarkKnight, Spells.HardSlash);
 
         public static readonly List<uint> Defensives = new List<uint>()
         {
-            Auras.Foresight,
             Auras.LivingDead,
-            Auras.DarkDance,
-            Auras.Shadowskin,
-            Auras.ShadowWall
+            Auras.ShadowWall,
+            Auras.Rampart,
+            Auras.DarkMissionary,
+            Auras.BlackestNight,
+            Auras.DarkMind,
+            Auras.Oblation
         };
-
-        public static bool OnGcd => Spells.HardSlash.Cooldown > TimeSpan.FromMilliseconds(500);
     }
 }

--- a/Magitek/Views/UserControls/DarkKnight/Defensives.xaml
+++ b/Magitek/Views/UserControls/DarkKnight/Defensives.xaml
@@ -93,6 +93,23 @@
         </controls:SettingsBlock>
 
         <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
+            <StackPanel Margin="5">
+
+                <StackPanel Orientation="Horizontal">
+                    <CheckBox Grid.Column="0" Content="Oblation " IsChecked="{Binding DarkKnightSettings.UseOblation, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <controls:Numeric Grid.Column="1" MaxValue="100" MinValue="1" Value="{Binding DarkKnightSettings.UseOblationAtHpPercent, Mode=TwoWay}" />
+                    <TextBlock Grid.Column="2" Margin="2,0,3,0" Style="{DynamicResource TextBlockDefault}" Text="Health Percent" />
+                </StackPanel>
+                <StackPanel Margin="0,3" Orientation="Horizontal">
+                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="Use On " />
+                    <CheckBox Content="Tanks " IsChecked="{Binding DarkKnightSettings.UseOblationOnTanks, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <CheckBox Content="Healers " IsChecked="{Binding DarkKnightSettings.UseOblationOnHealers, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <CheckBox Content="DPS " IsChecked="{Binding DarkKnightSettings.UseOblationOnDPS, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                </StackPanel>
+            </StackPanel>
+        </controls:SettingsBlock>
+
+        <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
             <StackPanel Margin="5" Orientation="Horizontal">
                 <CheckBox Content="Reprisal" IsChecked="{Binding DarkKnightSettings.UseReprisal, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
             </StackPanel>


### PR DESCRIPTION
Some testing performed in trusts but below level 90. Please give any feedback on Discord, and use in raids or max level dungeons only with some caution.

* Added UseAoe settings checks to AOE skills
* Removed commented out TankBuster code
* Fixed bug in defensives which would check against the wrong skills, updated defensive auras
* Added support for Oblation skill, including basic support for casting on party members, with settings
* Added basic support for Shadowbringers skill, no optimization/logic implemented yet
* Updated distance values for Unmend
* Removed logging from plunge
* Added settings for AutonomousPullDistance and AutonomousCombatDistance
* Dark Mind now defaults to true
* Dark Missionary now defaults to true
* Shadow Wall now defaults to true
* Living Dead now defaults to true (hp very low, 10%)
* Added Oblation Aura