### PR TITLE
WAR improvement

### DIFF
--- a/Magitek/Logic/Samurai/Aoe.cs
+++ b/Magitek/Logic/Samurai/Aoe.cs
@@ -3,6 +3,7 @@ using ff14bot.Managers;
 using Magitek.Extensions;
 using Magitek.Models.Samurai;
 using Magitek.Utilities;
+using SamuraiRoutine = Magitek.Utilities.Routines.Samurai;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
@@ -12,7 +13,8 @@ namespace Magitek.Logic.Samurai
 {
     internal static class Aoe
     {
-        public static async Task<bool> Fuga()
+        
+        public static async Task<bool> Fuko()
         {
             if (SamuraiSettings.Instance.OnlyAoeComboWithJinpuShifu && (!Core.Me.HasAura(Auras.Shifu) || !Core.Me.HasAura(Auras.Jinpu)))
                 return false;
@@ -20,29 +22,32 @@ namespace Magitek.Logic.Samurai
             if (!SamuraiSettings.Instance.AoeCombo)
                 return false;
 
-            if (Utilities.Routines.Samurai.SenCount == 2)
+            if (SamuraiRoutine.SenCount == 2)
                 return false;
 
             //if (!Core.Me.HasAura(Auras.Jinpu, true, 4000) || !Core.Me.HasAura(Auras.Shifu, true, 4000))
             //    return false;
 
-            if (SamuraiSettings.Instance.UseConeBasedAoECalculationMethod)
+            if (!Spells.Fuko.IsKnown()) // Fuko ( lvl < 86) is a cone based attack
             {
-                if (Core.Me.EnemiesInCone(5.5f) < SamuraiSettings.Instance.AoeComboEnemies)
+                if (SamuraiSettings.Instance.UseConeBasedAoECalculationMethod && Core.Me.EnemiesInCone(5.5f) < SamuraiSettings.Instance.AoeComboEnemies)
                     return false;
             }
             else
             {
-                if (Utilities.Routines.Samurai.AoeEnemies5Yards < SamuraiSettings.Instance.AoeComboEnemies)
+                if (SamuraiRoutine.AoeEnemies5Yards < SamuraiSettings.Instance.AoeComboEnemies)
                     return false;
             }
 
-            return await Spells.Fuga.Cast(Core.Me.CurrentTarget);
+            return await SamuraiRoutine.Fuko.Cast(Core.Me.CurrentTarget);
         }
 
+        /**********************************************************************************************
+         *                                    Combo 1 To get Ka (purple)
+         * ********************************************************************************************/
         public static async Task<bool> Oka()
         {
-            if (Utilities.Routines.Samurai.SenCount == 2)
+            if (SamuraiRoutine.SenCount == 2)
                 return false;
 
             if (ActionManager.LastSpell != Spells.Fuga && !Core.Me.HasAura(Auras.MeikyoShisui))
@@ -52,15 +57,18 @@ namespace Magitek.Logic.Samurai
                 return false;
             if (!Core.Me.HasAura(Auras.Jinpu, true, 7000))
                 return false;
-            if (Utilities.Routines.Samurai.AoeEnemies5Yards < SamuraiSettings.Instance.AoeComboEnemies)
+            if (SamuraiRoutine.AoeEnemies5Yards < SamuraiSettings.Instance.AoeComboEnemies)
                 return false;
 
             return await Spells.Oka.Cast(Core.Me);
         }
 
+        /**********************************************************************************************
+         *                                    Combo 2 To get Getsu (blue)
+         * ********************************************************************************************/
         public static async Task<bool> Mangetsu()
         {
-            if (Utilities.Routines.Samurai.SenCount == 2)
+            if (SamuraiRoutine.SenCount == 2)
                 return false;
 
             if (ActionManager.LastSpell != Spells.Fuga && !Core.Me.HasAura(Auras.MeikyoShisui))
@@ -68,9 +76,11 @@ namespace Magitek.Logic.Samurai
 
             if (ActionResourceManager.Samurai.Sen.HasFlag(Iaijutsu.Getsu))
                 return false;
+
             if (!Core.Me.HasAura(Auras.Shifu, true, 7000))
                 return false;
-            if (Utilities.Routines.Samurai.AoeEnemies5Yards < SamuraiSettings.Instance.AoeComboEnemies)
+
+            if (SamuraiRoutine.AoeEnemies5Yards < SamuraiSettings.Instance.AoeComboEnemies)
                 return false;
 
             return await Spells.Mangetsu.Cast(Core.Me);
@@ -113,7 +123,7 @@ namespace Magitek.Logic.Samurai
             }
             else
             {
-                if (Utilities.Routines.Samurai.AoeEnemies8Yards < SamuraiSettings.Instance.TenkaGokenEnemies)
+                if (SamuraiRoutine.AoeEnemies8Yards < SamuraiSettings.Instance.TenkaGokenEnemies)
                     return false;
             }
 
@@ -178,20 +188,6 @@ namespace Magitek.Logic.Samurai
                 return false;
 
             return await Spells.HissatsuKyuten.Cast(Core.Me.CurrentTarget);
-        }
-
-        public static async Task<bool> Fuko()
-        {
-            if (!SamuraiSettings.Instance.Fuko)
-                return false;
-
-            if (Core.Me.ClassLevel < 86)
-                return false;
-
-            if (Utilities.Routines.Samurai.AoeEnemies5Yards < SamuraiSettings.Instance.FukoEnemies)
-                return false;
-
-            return await Spells.Fuko.Cast(Core.Me.CurrentTarget);
         }
 
         public static async Task<bool> ShohaII()

--- a/Magitek/Logic/Warrior/Aoe.cs
+++ b/Magitek/Logic/Warrior/Aoe.cs
@@ -16,10 +16,16 @@ namespace Magitek.Logic.Warrior
             if (!WarriorSettings.Instance.UseAoe)
                 return false;
 
+            if (!WarriorSettings.Instance.UseChaoticCyclone)
+                return false;
+
             if (!Core.Me.HasAura(Auras.NascentChaos))
                 return false;
 
             if (!Core.Me.HasAura(Auras.SurgingTempest))
+                return false;
+
+            if (!Core.Me.HasAura(Auras.InnerRelease) && !WarriorSettings.Instance.UseBeastGauge)
                 return false;
 
             if (Combat.Enemies.Count(x => x.Distance(Core.Me) <= 5 + x.CombatReach) < WarriorSettings.Instance.ChaoticCycloneMinimumEnemies)
@@ -43,7 +49,7 @@ namespace Magitek.Logic.Warrior
             if (Core.Me.HasAura(Auras.NascentChaos))
                 return false;
 
-            if (!Core.Me.HasAura(Auras.InnerRelease) && ActionResourceManager.Warrior.BeastGauge < WarriorSettings.Instance.KeepAtLeastXBeastGauge)
+            if (!Core.Me.HasAura(Auras.InnerRelease) && !WarriorSettings.Instance.UseBeastGauge)
                 return false;
 
             if (Combat.Enemies.Count(x => x.Distance(Core.Me) <= 5 + x.CombatReach) < WarriorSettings.Instance.DecimateMinimumEnemies)
@@ -97,9 +103,6 @@ namespace Magitek.Logic.Warrior
 
         public static async Task<bool> PrimalRend()
         {
-            if (!WarriorSettings.Instance.UseAoe)
-                return false;
-
             if (!WarriorSettings.Instance.UsePrimalRend)
                 return false;
 

--- a/Magitek/Logic/Warrior/Buff.cs
+++ b/Magitek/Logic/Warrior/Buff.cs
@@ -39,9 +39,6 @@ namespace Magitek.Logic.Warrior
             if (!WarriorSettings.Instance.UseInnerRelease)
                 return false;
 
-            if (Core.Me.CurrentTarget == null)
-                return false;
-
             if (Combat.Enemies.Count(r => r.Distance(Core.Me) <= 3 + r.CombatReach) < 1)
                 return false;
 
@@ -76,7 +73,6 @@ namespace Magitek.Logic.Warrior
             if (ActionResourceManager.Warrior.BeastGauge >= WarriorSettings.Instance.UseInfuriateAtBeastGauge)
                 return false;
 
-            Logger.WriteInfo($@"Infuriate Ready");
             return await Spells.Infuriate.Cast(Core.Me);
         }
 

--- a/Magitek/Logic/Warrior/SingleTarget.cs
+++ b/Magitek/Logic/Warrior/SingleTarget.cs
@@ -158,17 +158,20 @@ namespace Magitek.Logic.Warrior
         }
 
         /*************************************************************************************
-         *                                Special GCD
+         *                           Special GCD using Beast Gauge
          * ***********************************************************************************/
         public static async Task<bool> FellCleave()
         {
+            if (!WarriorSettings.Instance.UseFellCleave)
+                return false;
+
             if (Core.Me.HasAura(Auras.NascentChaos))
                 return false;
 
             if (!Core.Me.HasAura(Auras.SurgingTempest))
                 return false;
 
-            if (!Core.Me.HasAura(Auras.InnerRelease) && ActionResourceManager.Warrior.BeastGauge <= WarriorSettings.Instance.KeepAtLeastXBeastGauge)
+            if (!Core.Me.HasAura(Auras.InnerRelease) && !WarriorSettings.Instance.UseBeastGauge)
                 return false;
 
             return await WarriorRoutine.FellCleave.Cast(Core.Me.CurrentTarget);
@@ -183,6 +186,9 @@ namespace Magitek.Logic.Warrior
                 return false;
 
             if (!Core.Me.HasAura(Auras.SurgingTempest))
+                return false;
+
+            if (!Core.Me.HasAura(Auras.InnerRelease) && !WarriorSettings.Instance.UseBeastGauge)
                 return false;
 
             return await Spells.InnerChaos.Cast(Core.Me.CurrentTarget);

--- a/Magitek/Models/Warrior/WarriorSettings.cs
+++ b/Magitek/Models/Warrior/WarriorSettings.cs
@@ -13,8 +13,12 @@ namespace Magitek.Models.Warrior
         public static WarriorSettings Instance { get; set; } = new WarriorSettings();
 
         [Setting]
-        [DefaultValue(50)]
-        public int KeepAtLeastXBeastGauge { get; set; }
+        [DefaultValue(true)]
+        public bool UseBeastGauge { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
+        public bool UseFellCleave { get; set; }
 
         [Setting]
         [DefaultValue(true)]
@@ -33,7 +37,6 @@ namespace Magitek.Models.Warrior
         [DefaultValue(true)]
         public bool UseInnerRelease { get; set; }
         #endregion
-
 
         #region Heal
         [Setting]
@@ -68,7 +71,6 @@ namespace Magitek.Models.Warrior
         [DefaultValue(50)]
         public int ThrillOfBattleHpPercentage { get; set; }
         #endregion
-
 
         #region Defensives
         [Setting]
@@ -129,6 +131,13 @@ namespace Magitek.Models.Warrior
         [DefaultValue(true)]
         public bool UseAoe { get; set; }
 
+        [Setting]
+        [DefaultValue(true)]
+        public bool UseChaoticCyclone { get; set; }
+
+        [Setting]
+        [DefaultValue(3)]
+        public int ChaoticCycloneMinimumEnemies { get; set; }
 
         [Setting]
         [DefaultValue(true)]
@@ -137,10 +146,6 @@ namespace Magitek.Models.Warrior
         [Setting]
         [DefaultValue(3)]
         public int DecimateMinimumEnemies { get; set; }
-
-        [Setting]
-        [DefaultValue(3)]
-        public int ChaoticCycloneMinimumEnemies { get; set; }
 
         [Setting]
         [DefaultValue(true)]

--- a/Magitek/Rotations/Samurai.cs
+++ b/Magitek/Rotations/Samurai.cs
@@ -116,14 +116,10 @@ namespace Magitek.Rotations
             if (await Aoe.TenkaGoken()) return true;
             if (await Aoe.Oka()) return true;
             if (await Aoe.Mangetsu()) return true;
-            if (await Aoe.Fuga()) return true;
+            if (await Aoe.Fuko()) return true;
             if (await Aoe.OgiNamikiri()) return true;
             if (await Aoe.KaeshiNamikiri()) return true;
-
             if (await SingleTarget.Higanbana()) return true;
-
-
-
             if (await SingleTarget.Gekko()) return true;
             if (await SingleTarget.Kasha()) return true;
             if (await SingleTarget.Yukikaze()) return true;

--- a/Magitek/Rotations/Warrior.cs
+++ b/Magitek/Rotations/Warrior.cs
@@ -75,11 +75,11 @@ namespace Magitek.Rotations
                 if (await Defensive.Holmgang()) return true;
                 if (await Healing.Equilibrium()) return true;
                 if (await Healing.ThrillOfBattle()) return true;
+                if (await Defensive.BloodWhetting()) return true;
                 if (await Defensive.Reprisal()) return true;
                 if (await Defensive.Rampart()) return true;
                 if (await Defensive.Vengeance()) return true;
                 if (await Defensive.ShakeItOff()) return true;
-                if (await Defensive.BloodWhetting()) return true;
                 if (await Buff.NascentFlash()) return true;
 
                 //Cooldowns

--- a/Magitek/Utilities/Routines/Samurai.cs
+++ b/Magitek/Utilities/Routines/Samurai.cs
@@ -18,6 +18,10 @@ namespace Magitek.Utilities.Routines
 
         public static bool OnGcd => Spells.Hakaze.Cooldown > TimeSpan.FromMilliseconds(SamuraiSettings.Instance.UseOffGCDAbilitiesWithMoreThanXMSLeft);
 
+        public static SpellData Fuko => Core.Me.ClassLevel < 86
+                                                    ? Spells.Fuga
+                                                    : Spells.Fuko;
+
         public static int SenCount
         {
             get

--- a/Magitek/Views/UserControls/Warrior/Combat.xaml
+++ b/Magitek/Views/UserControls/Warrior/Combat.xaml
@@ -24,24 +24,41 @@
     </UserControl.Resources>
 
     <StackPanel Margin="10">
-
         <controls:SettingsBlock Background="{DynamicResource ClassSelectorBackground}">
             <StackPanel Margin="5">
                 <StackPanel Margin="5" Orientation="Horizontal">
-                    <CheckBox Content="Use Onslaught " IsChecked="{Binding WarriorSettings.UseOnslaught, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <CheckBox Content="Use Beast Gauge (ChaoticCyclone/Decimation/Fellcleave/InnerChaos won't be used outside IR) " IsChecked="{Binding WarriorSettings.UseBeastGauge, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                 </StackPanel>
+                <StackPanel Margin="5" Orientation="Horizontal">
+                    <CheckBox Content="Use FellCleave " IsChecked="{Binding WarriorSettings.UseFellCleave, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                </StackPanel>
+                <StackPanel Margin="5" Orientation="Horizontal">
+                    <CheckBox Content="Use InnerChaos " IsChecked="{Binding WarriorSettings.UseInnerChaos, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                </StackPanel>
+                
                 <StackPanel Margin="5" Orientation="Horizontal">
                     <CheckBox Content="Use Primal Rend " IsChecked="{Binding WarriorSettings.UsePrimalRend, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                 </StackPanel>
                 <StackPanel Margin="5" Orientation="Horizontal">
-                    <CheckBox Content="Steel Cyclone / Decimate When There Are " IsChecked="{Binding WarriorSettings.UseDecimate, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <CheckBox Content="Use Onslaught " IsChecked="{Binding WarriorSettings.UseOnslaught, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                </StackPanel>
+            </StackPanel>
+        </controls:SettingsBlock>
+
+        <controls:SettingsBlock Margin="0,5,0,0" Background="{DynamicResource ClassSelectorBackground}">
+            <StackPanel Margin="5">
+                <StackPanel Margin="5" Orientation="Horizontal">
+                    <CheckBox Content="Use Aoe (Overpower, Mythril, Orogeny, ChaoticCyclone, Decimate)" IsChecked="{Binding WarriorSettings.UseAoe, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                </StackPanel>
+                <StackPanel Margin="5" Orientation="Horizontal">
+                    <CheckBox Content="Use Steel Cyclone / Decimate When There Are " IsChecked="{Binding WarriorSettings.UseDecimate, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                     <controls:Numeric MaxValue="50" MinValue="1" Value="{Binding WarriorSettings.DecimateMinimumEnemies, Mode=TwoWay}" />
                     <TextBlock Style="{DynamicResource TextBlockDefault}" Text=" Enemies In Range" />
                 </StackPanel>
                 <StackPanel Margin="5" Orientation="Horizontal">
-                    <TextBlock Text="Always Keep At Least " Style="{DynamicResource TextBlockDefault}" />
-                    <controls:Numeric Increment="10" MaxValue="100" MinValue="0" Value="{Binding WarriorSettings.KeepAtLeastXBeastGauge, Mode=TwoWay}"/>
-                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text=" Beast Gauge for Own Use of Onslaught" />
+                    <CheckBox Content="Use Chaotic Cyclone When There Are " IsChecked="{Binding WarriorSettings.UseChaoticCyclone, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <controls:Numeric MaxValue="50" MinValue="1" Value="{Binding WarriorSettings.ChaoticCycloneMinimumEnemies, Mode=TwoWay}" />
+                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text=" Enemies In Range" />
                 </StackPanel>
             </StackPanel>
         </controls:SettingsBlock>

--- a/Magitek/Views/UserControls/Warrior/Defensives.xaml
+++ b/Magitek/Views/UserControls/Warrior/Defensives.xaml
@@ -17,13 +17,6 @@
         <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
             <StackPanel Margin="5">
 
-                <!--<CheckBox Content="Use Tank Busters  " IsChecked="{Binding WarriorSettings.UseTankBusters, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />-->
-
-                <!--<StackPanel Margin="0,3,0,0" Orientation="Horizontal">
-                    <CheckBox Content="Use Defensives  " IsChecked="{Binding WarriorSettings.UseDefensives, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                    <CheckBox Content="Only On Tank Busters" IsChecked="{Binding WarriorSettings.UseDefensivesOnlyOnTankBusters, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                </StackPanel>-->
-
                 <StackPanel Margin="0,10">
 
                     <StackPanel Orientation="Horizontal">
@@ -77,7 +70,7 @@
                                       Value="{Binding WarriorSettings.VengeanceHpPercentage, Mode=TwoWay}" />
                     <TextBlock Grid.Row="1" Grid.Column="2" Style="{DynamicResource TextBlockDefault}" Text=" Health Percent" />
 
-                    <CheckBox Grid.Row="2" Grid.Column="0" Content="Raw Intuition / Bloodwhetting" IsChecked="{Binding WarriorSettings.UseBloodWhetting, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <CheckBox Grid.Row="2" Grid.Column="0" Content="Raw Intuition / Bloodwhetting  " IsChecked="{Binding WarriorSettings.UseBloodWhetting, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                     <controls:Numeric Grid.Row="2"
                                       Grid.Column="1"
                                       Margin="0,3"


### PR DESCRIPTION
WAR:
- Add new Toggle UseBeastGauge to not use Fellcleave, Innerchaos, ChaoticCyclone, decimate outside InnerRelease
- Add new Toggle: UseChaoticCyclone
- Add new Toggle: UseFellCleave
- Add new Toggle: Remove PrimalRend from Toggle UseAoe as it is part of SingleTarget Rotation
- Remove Toggle KeepAtLeastXBeastGauge as Onslaught doesn't use beast gauge anymore
- Prior Bloodwhetting to other Defensives buffs
- UI combat improvement

SAM:
- Update Fuga to Fuko