### PR TITLE
Sage Kardia updates & other fixes. 

### DIFF
--- a/Magitek/Extensions/GameObjectExtensions.cs
+++ b/Magitek/Extensions/GameObjectExtensions.cs
@@ -197,7 +197,11 @@ namespace Magitek.Extensions
         public static bool IsMainTank(this GameObject unit)
         {
             var gameObject = unit as Character;
-            return gameObject != null && Tanks.Contains(gameObject.CurrentJob) && (gameObject.BeingTargetedBy(Core.Me.CurrentTarget) || gameObject.BeingTargetedBy(gameObject.TargetGameObject));
+            return gameObject != null
+                && Tanks.Contains(gameObject.CurrentJob)
+                && (gameObject.BeingTargetedBy(Core.Me.CurrentTarget)
+                    || gameObject.BeingTargetedBy(gameObject.TargetGameObject)
+                    || PartyManager.AllMembers.Select(r => r.BattleCharacter).Where(r => Tanks.Contains(r.CurrentJob)).Count() == 1);
         }
 
         public static bool IsTank(this GameObject unit, bool mainTank)

--- a/Magitek/Logic/Sage/Buff.cs
+++ b/Magitek/Logic/Sage/Buff.cs
@@ -57,7 +57,7 @@ namespace Magitek.Logic.Sage
                     && Core.Me.InCombat
                     && (!SageSettings.Instance.KardiaSwitchTargetsCurrent || currentKardiaTarget.CurrentHealthPercent >= SageSettings.Instance.KardiaSwitchTargetsCurrentHealthPercent))
                 {
-                    var canKardiaTargets = Group.CastableAlliesWithin30.Where(CanKardia).OrderByDescending(KardiaPriority).ToList();
+                    var canKardiaTargets = Group.CastableAlliesWithin30.Where(CanKardia).Where(CanKardiaSwitch).OrderByDescending(KardiaPriority).ToList();
 
                     if (canKardiaTargets.Contains(currentKardiaTarget))
                         return false;
@@ -97,6 +97,14 @@ namespace Magitek.Logic.Sage
                 return await Spells.Kardia.CastAura(Core.Me, Auras.Kardion);
             }
 
+            bool CanKardiaSwitch(Character unit)
+            {
+                if (unit.CurrentHealthPercent > SageSettings.Instance.KardiaSwitchTargetsHealthPercent)
+                    return false;
+
+                return true;
+            }
+
             bool CanKardia(Character unit)
             {
                 if (unit == null)
@@ -105,22 +113,22 @@ namespace Magitek.Logic.Sage
                 if (!unit.IsAlive)
                     return false;
 
-                if (unit.CurrentHealthPercent > SageSettings.Instance.KardiaSwitchTargetsHealthPercent)
+                if (unit.Distance(Core.Me) > 30)
                     return false;
 
-                if (unit.IsHealer() && !SageSettings.Instance.KardiaHealer)
-                    return false;
+                if (unit.IsHealer() && SageSettings.Instance.KardiaHealer)
+                    return true;
 
-                if (unit.IsDps() && !SageSettings.Instance.KardiaDps)
-                    return false;
+                if (unit.IsDps() && SageSettings.Instance.KardiaDps)
+                    return true;
 
-                if (unit.IsMainTank() && !SageSettings.Instance.KardiaMainTank && !SageSettings.Instance.KardiaTank)
-                    return false;
+                if (unit.IsMainTank() && SageSettings.Instance.KardiaMainTank)
+                    return true;
 
-                else if (unit.IsTank() && !SageSettings.Instance.KardiaTank)
-                    return false;
+                if (unit.IsTank() && SageSettings.Instance.KardiaTank)
+                    return true;
 
-                return unit.Distance(Core.Me) <= 30;
+                return false;
             }
 
             int KardiaPriority(Character unit)

--- a/Magitek/Models/Sage/SageSettings.cs
+++ b/Magitek/Models/Sage/SageSettings.cs
@@ -31,6 +31,10 @@ namespace Magitek.Models.Sage
         public bool InterruptDamageToHeal { get; set; }
 
         [Setting]
+        [DefaultValue(80.0f)]
+        public float InterruptDamageHealthPercent { get; set; }
+
+        [Setting]
         [DefaultValue(true)]
         public bool DoDamage { get; set; }
 
@@ -89,6 +93,18 @@ namespace Magitek.Models.Sage
         [Setting]
         [DefaultValue(85)]
         public float KardiaSwitchTargetsHealthPercent { get; set; }
+
+        [Setting]
+        [DefaultValue(false)]
+        public bool KardiaSwitchTargetsCurrent { get; set; }
+
+        [Setting]
+        [DefaultValue(95)]
+        public float KardiaSwitchTargetsCurrentHealthPercent { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
+        public bool KardiaMainTank { get; set; }
 
         [Setting]
         [DefaultValue(true)]
@@ -157,14 +173,6 @@ namespace Magitek.Models.Sage
         [Setting]
         [DefaultValue(60.0f)]
         public float KeracholeHealthPercent { get; set; }
-
-        [Setting]
-        [DefaultValue(true)]
-        public bool Egeiro { get; set; }
-
-        [Setting]
-        [DefaultValue(true)]
-        public bool EgeiroSwiftcast { get; set; }
 
         [Setting]
         [DefaultValue(true)]

--- a/Magitek/Rotations/Sage.cs
+++ b/Magitek/Rotations/Sage.cs
@@ -82,7 +82,7 @@ namespace Magitek.Rotations
             if (await Logic.Sage.Heal.Egeiro()) return true;
             if (await Dispel.Execute()) return true;
 
-            if (SageRoutine.GlobalCooldown.CanWeave())
+            if (!SageSettings.Instance.WeaveOGCDHeals || SageRoutine.GlobalCooldown.CanWeave())
             {
                 if (await Buff.LucidDreaming()) return true;
                 if (await Buff.Kardia()) return true;

--- a/Magitek/Utilities/Routines/Sage.cs
+++ b/Magitek/Utilities/Routines/Sage.cs
@@ -36,27 +36,13 @@ namespace Magitek.Utilities.Routines
             if (SageSettings.Instance.InterruptHealing && Casting.DoHealthChecks &&
                 Casting.SpellTarget?.CurrentHealthPercent >= SageSettings.Instance.InterruptHealingHealthPercent)
             {
-                if (Casting.CastingSpell == Spells.Helios && PartyManager.VisibleMembers.Select(r => r.BattleCharacter).Count(r =>
-                        r.CurrentHealth > 0 && r.Distance(Core.Me) <= Spells.Helios.Radius && r.CurrentHealthPercent <=
+                if (Casting.CastingSpell == Spells.Prognosis && PartyManager.VisibleMembers.Select(r => r.BattleCharacter).Count(r =>
+                        r.CurrentHealth > 0 && r.Distance(Core.Me) <= Spells.Prognosis.Radius && r.CurrentHealthPercent <=
                         SageSettings.Instance.PrognosisHpPercent) <
                     SageSettings.Instance.PrognosisNeedHealing)
                 {
                     Logger.Error($@"Stopped Healing: Party's Health Too High");
                     return true;
-                }
-                if (Casting.CastingSpell == Spells.EukrasianPrognosis)
-                {
-                    if (PartyManager.VisibleMembers.Select(r => r.BattleCharacter).Count(r =>
-                            r.CurrentHealth > 0 &&
-                            r.Distance(Core.Me) <= Spells.EukrasianPrognosis.Radius &&
-                            r.CurrentHealthPercent <=
-                            SageSettings.Instance.EukrasianPrognosisHealthPercent &&
-                            !r.HasAura(Auras.EukrasianPrognosis, true)) <
-                        SageSettings.Instance.EukrasianPrognosisAllies)
-                    {
-                        Logger.Error($@"Stopped Healing: Party's Health Too High");
-                        return true;
-                    }
                 }
                 else
                 {
@@ -71,16 +57,8 @@ namespace Magitek.Utilities.Routines
                     Casting.CastingSpell == Spells.DosisIII || Casting.CastingSpell == Spells.Dyskrasia ||
                     Casting.CastingSpell == Spells.DyskrasiaII)
                 {
-
-                    var lowestHealthToInterruptList = new[]
-                    {
-                        SageSettings.Instance.Diagnosis ? SageSettings.Instance.DiagnosisHpPercent -10 : 0,
-                    };
-
-                    var lowestHealthToInterrupt = lowestHealthToInterruptList.Max();
-
                     if (PartyManager.VisibleMembers.Select(r => r.BattleCharacter).Any(r => r.CurrentHealth > 0 &&
-                        r.CurrentHealthPercent <= lowestHealthToInterrupt && r.Distance() < 30 && r.InLineOfSight()))
+                        r.CurrentHealthPercent <= SageSettings.Instance.InterruptDamageHealthPercent && r.Distance() < 30 && r.InLineOfSight()))
                     {
                         Logger.Error($@"Stopping Cast: Need To Heal Someone In The Party");
                         return true;

--- a/Magitek/Views/UserControls/Sage/Buffs.xaml
+++ b/Magitek/Views/UserControls/Sage/Buffs.xaml
@@ -66,6 +66,7 @@
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
                     <TextBlock Grid.Column="0"  Style="{DynamicResource TextBlockDefault}" Text="Allow Kardia on " />
                     <CheckBox Grid.Column="1" Content="Main Tank " IsChecked="{Binding SageSettings.KardiaMainTank, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />

--- a/Magitek/Views/UserControls/Sage/Buffs.xaml
+++ b/Magitek/Views/UserControls/Sage/Buffs.xaml
@@ -68,7 +68,7 @@
                         <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
                     <TextBlock Grid.Column="0"  Style="{DynamicResource TextBlockDefault}" Text="Allow Kardia on " />
-                    <CheckBox Grid.Column="1" Content="Main Tank " IsChecked="{Binding SageSettings.Kardia, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <CheckBox Grid.Column="1" Content="Main Tank " IsChecked="{Binding SageSettings.KardiaMainTank, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                     <CheckBox Grid.Column="2" Content="Any Tanks " IsChecked="{Binding SageSettings.KardiaTank, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                     <CheckBox Grid.Column="3" Content="Healers " IsChecked="{Binding SageSettings.KardiaHealer, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                     <CheckBox Grid.Column="4" Content="DPS " IsChecked="{Binding SageSettings.KardiaDps, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />

--- a/Magitek/Views/UserControls/Sage/Buffs.xaml
+++ b/Magitek/Views/UserControls/Sage/Buffs.xaml
@@ -35,7 +35,7 @@
                         <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
 
-                    <CheckBox Grid.Column="0" Content="Use Kardia" IsChecked="{Binding SageSettings.Kardia, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <CheckBox Grid.Column="0" Content="Use Kardia " IsChecked="{Binding SageSettings.Kardia, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                 </Grid>
                 <Grid Margin="0,5,0,0">
                     <Grid.ColumnDefinitions>
@@ -44,7 +44,7 @@
                         <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
 
-                    <CheckBox Grid.Column="0" Content="Switch Kardia Targets " IsChecked="{Binding SageSettings.KardiaSwitchTargets, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <CheckBox Grid.Column="0" Content="Switch Kardia Targets below " IsChecked="{Binding SageSettings.KardiaSwitchTargets, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                     <controls:Numeric Grid.Column="1" MaxValue="100" MinValue="1" Value="{Binding SageSettings.KardiaSwitchTargetsHealthPercent, Mode=TwoWay}" />
                     <TextBlock Grid.Column="2" Margin="2,0,3,0" Style="{DynamicResource TextBlockDefault}" Text="Health Percent" />
                 </Grid>
@@ -54,9 +54,24 @@
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
-                    <CheckBox Grid.Column="0" Content="Tanks " IsChecked="{Binding SageSettings.KardiaTank, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                    <CheckBox Grid.Column="1" Content="Healers " IsChecked="{Binding SageSettings.KardiaHealer, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                    <CheckBox Grid.Column="2" Content="DPS " IsChecked="{Binding SageSettings.KardiaDps, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+
+                    <CheckBox Grid.Column="0" Content="Only switch when current Kardia target is above " IsChecked="{Binding SageSettings.KardiaSwitchTargetsCurrent, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <controls:Numeric Grid.Column="1" MaxValue="100" MinValue="1" Value="{Binding SageSettings.KardiaSwitchTargetsCurrentHealthPercent, Mode=TwoWay}" />
+                    <TextBlock Grid.Column="2" Margin="2,0,3,0" Style="{DynamicResource TextBlockDefault}" Text="Health Percent" />
+                </Grid>
+                <Grid Margin="0,5,0,0">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Grid.Column="0"  Style="{DynamicResource TextBlockDefault}" Text="Allow Kardia on " />
+                    <CheckBox Grid.Column="1" Content="Main Tank " IsChecked="{Binding SageSettings.Kardia, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <CheckBox Grid.Column="2" Content="Any Tanks " IsChecked="{Binding SageSettings.KardiaTank, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <CheckBox Grid.Column="3" Content="Healers " IsChecked="{Binding SageSettings.KardiaHealer, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <CheckBox Grid.Column="4" Content="DPS " IsChecked="{Binding SageSettings.KardiaDps, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                 </Grid>
             </StackPanel>
         </controls:SettingsBlock>

--- a/Magitek/Views/UserControls/Sage/Combat.xaml
+++ b/Magitek/Views/UserControls/Sage/Combat.xaml
@@ -40,8 +40,8 @@
                 </StackPanel>
 
                 <StackPanel Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="4" Orientation="Horizontal">
-                    <CheckBox Content="Stop Casting A Damage Spell If Someone Drops " IsChecked="{Binding SageSettings.InterruptHealing, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                    <controls:Numeric MaxValue="100" MinValue="1" Value="{Binding SageSettings.InterruptHealingHealthPercent, Mode=TwoWay}" />
+                    <CheckBox Content="Stop Casting A Damage Spell If Someone Drops Below " IsChecked="{Binding SageSettings.InterruptDamageToHeal, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <controls:Numeric MaxValue="100" MinValue="1" Value="{Binding SageSettings.InterruptDamageHealthPercent, Mode=TwoWay}" />
                     <TextBlock Style="{DynamicResource TextBlockDefault}" Text=" Health Percent" />
                 </StackPanel>
             </Grid>
@@ -122,7 +122,7 @@
                 <controls:Numeric MaxValue="100" MinValue="1" Value="{Binding SageSettings.AoEEnemies, Mode=TwoWay}" />
                 <TextBlock Style="{DynamicResource TextBlockDefault}" Text=" Enemies In Range" />
             </StackPanel>
-            
+
         </controls:SettingsBlock>
         <controls:SettingsBlock Background="{DynamicResource ClassSelectorBackground}">
             <StackPanel Margin="5" Orientation="Horizontal">
@@ -142,17 +142,17 @@
 
         </controls:SettingsBlock>
         <Border Grid.Row="7" Padding="5,2">
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="112" />
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="Auto" />
-                        </Grid.ColumnDefinitions>
-                    </Grid>
-                </Border>
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="112" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+            </Grid>
+        </Border>
 
 
     </StackPanel>

--- a/Magitek/Views/UserControls/Sage/Healing.xaml
+++ b/Magitek/Views/UserControls/Sage/Healing.xaml
@@ -18,6 +18,13 @@
     </UserControl.Resources>
 
     <StackPanel Margin="10">
+        <controls:SettingsBlock Margin="0" Background="{DynamicResource ClassSelectorBackground}">
+            <StackPanel Margin="5"  Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="4" Orientation="Horizontal">
+                <CheckBox Content="Interrupt Healing If Target HP Gets Over " IsChecked="{Binding SageSettings.InterruptHealing, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                <controls:Numeric MaxValue="100" MinValue="1" Value="{Binding SageSettings.InterruptHealingHealthPercent, Mode=TwoWay}" />
+                <TextBlock Style="{DynamicResource TextBlockDefault}" Text=" Health Percent" />
+            </StackPanel>
+        </controls:SettingsBlock>
 
         <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
             <Grid Margin="5">


### PR DESCRIPTION
- Fixed lucid dreaming not casting under certain circumstances
- Fixed interrupt heal and interrupt damage ( Check your UI settings for these!!! The UI previously had them swapped ).
- Weave buffs if WeaveOGCDs is set
- More improvements to Kardia logic. Added guard to only switch kardia if current target is above a threshold. Improved main tank selection and kardia will cast outside of combat again. 