### PR TITLE
[DRK] Remove Dark Mind and Dark Missionary from the defensives at the…

### DIFF
--- a/Magitek/Utilities/Routines/DarkKnight.cs
+++ b/Magitek/Utilities/Routines/DarkKnight.cs
@@ -13,9 +13,7 @@ namespace Magitek.Utilities.Routines
             Auras.LivingDead,
             Auras.ShadowWall,
             Auras.Rampart,
-            Auras.DarkMissionary,
             Auras.BlackestNight,
-            Auras.DarkMind,
             Auras.Oblation
         };
     }

--- a/Magitek/Views/UserControls/DarkKnight/Defensives.xaml
+++ b/Magitek/Views/UserControls/DarkKnight/Defensives.xaml
@@ -28,6 +28,10 @@
                         <TextBlock Style="{DynamicResource TextBlockDefault}" Text=" Defensive Buffs At The Same Time" />
                     </StackPanel>
 
+                    <StackPanel>
+                        <TextBlock Style="{DynamicResource TextBlockDefault}" Text="    NOTE: Does not include Dark Mind and Dark Missionary" />
+                    </StackPanel>
+
                     <StackPanel Orientation="Horizontal">
                         <TextBlock Style="{DynamicResource TextBlockDefault}" Text="Unless You Are Lower Than " />
                         <controls:Numeric Margin="0,3" MaxValue="100" MinValue="1" Value="{Binding DarkKnightSettings.MoreDefensivesHp, Mode=TwoWay}" />


### PR DESCRIPTION
… same time check. This should hopefully allow them to be used more automatically without compromising DRK survavability.