### PR TITLE
Update MagitekLoader.cs

### DIFF
--- a/MagitekLoader/MagitekLoader.cs
+++ b/MagitekLoader/MagitekLoader.cs
@@ -120,7 +120,7 @@ namespace MagitekLoader
         public override void Initialize()
         {
             if (!_loaded && Product == null && _updaterFinished) { LoadProduct(); }
-            if (Product != null) { InitFunc.Invoke(Product, null); }
+           // if (Product != null) { InitFunc.Invoke(Product, null); }
         }
 
         public override void OnButtonPress()


### PR DESCRIPTION
Fix a bug that causes initialization twice, resulting in magitek's TreeRoot event not being completely removed when switching CombatRoutine.