### PR TITLE
SAM Update 6.x - Some fixes

### DIFF
--- a/Magitek/Enumerations/SamuraiFillerStrategy.cs
+++ b/Magitek/Enumerations/SamuraiFillerStrategy.cs
@@ -2,9 +2,9 @@
 {
     public enum SamuraiFillerStrategy
     {
-        None,
         TwoGCD,
         ThreeGCD,
         FourGCD,
+        None,
     }
 }

--- a/Magitek/Logic/Samurai/Aoe.cs
+++ b/Magitek/Logic/Samurai/Aoe.cs
@@ -38,13 +38,21 @@ namespace Magitek.Logic.Samurai
             if (!SamuraiSettings.Instance.UseAoe)
                 return false;
 
-            if (!Core.Me.HasAura(Auras.MeikyoShisui) && !SamuraiRoutine.CanContinueComboAfter(SamuraiRoutine.Fuko))
-                return false;
-
             if (ActionResourceManager.Samurai.Sen.HasFlag(Iaijutsu.Ka))
-                return false;
-
-            if (Core.Me.HasAura(Auras.MeikyoShisui) && SamuraiRoutine.AoeEnemies5Yards < SamuraiSettings.Instance.AoeEnemies)
+                return false; 
+            
+            if (Core.Me.HasAura(Auras.MeikyoShisui))
+            {
+                if (SamuraiRoutine.AoeEnemies5Yards < SamuraiSettings.Instance.AoeEnemies)
+                    return false;
+            } 
+            else
+            {
+                if (!SamuraiRoutine.CanContinueComboAfter(SamuraiRoutine.Fuko))
+                    return false;
+            }
+                
+            if (SamuraiRoutine.AoeEnemies5Yards < SamuraiSettings.Instance.AoeEnemies)
                 return false;
 
             return await Spells.Oka.Cast(Core.Me);
@@ -58,14 +66,19 @@ namespace Magitek.Logic.Samurai
             if (!SamuraiSettings.Instance.UseAoe)
                 return false;
 
-            if (!SamuraiRoutine.CanContinueComboAfter(SamuraiRoutine.Fuko) && !Core.Me.HasAura(Auras.MeikyoShisui))
-                return false;
-
             if (ActionResourceManager.Samurai.Sen.HasFlag(Iaijutsu.Getsu))
                 return false;
 
-            if (Core.Me.HasAura(Auras.MeikyoShisui) && SamuraiRoutine.AoeEnemies5Yards < SamuraiSettings.Instance.AoeEnemies)
-                return false;
+            if (Core.Me.HasAura(Auras.MeikyoShisui))
+            {
+                if (SamuraiRoutine.AoeEnemies5Yards < SamuraiSettings.Instance.AoeEnemies)
+                    return false;
+            }
+            else
+            {
+                if (!SamuraiRoutine.CanContinueComboAfter(SamuraiRoutine.Fuko))
+                    return false;
+            }
 
             return await Spells.Mangetsu.Cast(Core.Me);
         }
@@ -85,7 +98,7 @@ namespace Magitek.Logic.Samurai
             if (SamuraiRoutine.AoeEnemies5Yards < SamuraiSettings.Instance.AoeEnemies)
                 return false;
 
-            if (Spells.HissatsuGuren.IsKnownAndReady(10000))
+            if (Spells.HissatsuGuren.IsKnownAndReady(10000) && ActionResourceManager.Samurai.Kenki < 50 + SamuraiSettings.Instance.ReservedKenki)
                 return false;
 
             return await Spells.HissatsuKyuten.Cast(Core.Me.CurrentTarget);
@@ -160,9 +173,6 @@ namespace Magitek.Logic.Samurai
             if (!SamuraiSettings.Instance.UseKaeshiGoken)
                 return false;
 
-            if (SamuraiRoutine.AoeEnemies5Yards < SamuraiSettings.Instance.AoeEnemies)
-                return false;
-
             return await Spells.KaeshiGoken.Cast(Core.Me.CurrentTarget);
         }
 
@@ -192,7 +202,6 @@ namespace Magitek.Logic.Samurai
                 return false;
 
             SamuraiRoutine.InitializeFillerVar(false, false); // Remove Filler after Even Minutes Burst
-            Logger.WriteInfo($@"[Filler] Remove Filler after Even Minutes Burst");
 
             return true;
         }

--- a/Magitek/Logic/Samurai/Buff.cs
+++ b/Magitek/Logic/Samurai/Buff.cs
@@ -12,6 +12,20 @@ namespace Magitek.Logic.Samurai
 {
     internal static class Buff
     {
+        public static async Task<bool> MeikyoShisuiNotInCombat()
+        {
+            if (Core.Me.InCombat)
+                return false; 
+            
+            if (!SamuraiSettings.Instance.UseMeikyoShisui)
+                return false;
+
+            if (Core.Me.HasAura(Auras.MeikyoShisui))
+                return false;
+
+            return await Spells.MeikyoShisui.CastAura(Core.Me, Auras.MeikyoShisui);
+        }
+
         public static async Task<bool> MeikyoShisui()
         {
             if (!SamuraiSettings.Instance.UseMeikyoShisui)
@@ -23,24 +37,15 @@ namespace Magitek.Logic.Samurai
             if (SamuraiSettings.Instance.UseMeikyoShisuiOnlyWithZeroSen && SamuraiRoutine.SenCount > 0)
                 return false;
 
-            if (!Core.Me.HasAura(Auras.Jinpu, true, 7000) || !Core.Me.HasAura(Auras.Shifu, true, 7000))
-                return false;
-
             if (SamuraiRoutine.AoeEnemies5Yards < SamuraiSettings.Instance.AoeEnemies)
             {
-                if (ActionManager.LastSpell == Spells.Hakaze || ActionManager.LastSpell == Spells.Shifu || ActionManager.LastSpell == Spells.Jinpu
-                || Casting.LastSpell == Spells.Hakaze || Casting.LastSpell == Spells.Shifu || Casting.LastSpell == Spells.Jinpu)
-                    return false;
-
                 if (SamuraiRoutine.SenCount == 3)
                     return false;
 
-                if (Spells.HissatsuSenei.IsKnownAndReady())
+                if (Casting.LastSpell != Spells.KaeshiSetsugekka && Casting.LastSpell != Spells.KaeshiHiganbana && Casting.LastSpell != null)
                     return false;
-
-                if (Casting.LastSpell != Spells.KaeshiSetsugekka && Casting.LastSpell != Spells.KaeshiHiganbana)
-                    return false;
-            } else
+            } 
+            else
             {
                 if (SamuraiSettings.Instance.UseAoe)
                 {

--- a/Magitek/Logic/Samurai/Buff.cs
+++ b/Magitek/Logic/Samurai/Buff.cs
@@ -15,12 +15,27 @@ namespace Magitek.Logic.Samurai
         public static async Task<bool> MeikyoShisuiNotInCombat()
         {
             if (Core.Me.InCombat)
-                return false; 
-            
+                return false;
+
+            if (!Core.Me.HasTarget)
+                return false;
+
             if (!SamuraiSettings.Instance.UseMeikyoShisui)
                 return false;
 
             if (Core.Me.HasAura(Auras.MeikyoShisui))
+                return false;
+
+            if (Core.Me.HasAura(Auras.Shifu, true))
+                return false;
+
+            if (Core.Me.HasAura(Auras.Jinpu, true))
+                return false;
+
+            if (SamuraiRoutine.SenCount > 0)
+                return false;
+
+            if (ActionResourceManager.Samurai.Kenki > 0)
                 return false;
 
             return await Spells.MeikyoShisui.CastAura(Core.Me, Auras.MeikyoShisui);

--- a/Magitek/Logic/Samurai/SingleTarget.cs
+++ b/Magitek/Logic/Samurai/SingleTarget.cs
@@ -185,7 +185,6 @@ namespace Magitek.Logic.Samurai
 
         public static async Task<bool> HissatsuShinten()
         {
-            //Logger.Write($@"Kenki Jauge = {ActionResourceManager.Samurai.Kenki} ");
             if (!SamuraiSettings.Instance.UseHissatsuShinten)
                 return false;
 

--- a/Magitek/Models/Samurai/SamuraiSettings.cs
+++ b/Magitek/Models/Samurai/SamuraiSettings.cs
@@ -32,7 +32,7 @@ namespace Magitek.Models.Samurai
         public int ReservedKenki { get; set; }
 
         [Setting]
-        [DefaultValue(SamuraiFillerStrategy.ThreeGCD)]
+        [DefaultValue(SamuraiFillerStrategy.TwoGCD)]
         public SamuraiFillerStrategy SamuraiFillerStrategy { get; set; }
 
 

--- a/Magitek/Rotations/Samurai.cs
+++ b/Magitek/Rotations/Samurai.cs
@@ -82,6 +82,9 @@ namespace Magitek.Rotations
                 if (await SpellQueueLogic.SpellQueueMethod()) 
                     return true;
 
+            //Buff for opener
+            if (await Buff.MeikyoShisuiNotInCombat()) return true;
+
             //Utility
             if (await PhysicalDps.Interrupt(SamuraiSettings.Instance)) return true;
             if (await PhysicalDps.SecondWind(SamuraiSettings.Instance)) return true;
@@ -132,8 +135,8 @@ namespace Magitek.Rotations
             if (SamuraiRoutine.iaijutsuSuccessful)
             {
                 //Combo AOE
-                if (await Aoe.Oka()) return true;
                 if (await Aoe.Mangetsu()) return true;
+                if (await Aoe.Oka()) return true;
                 if (await Aoe.Fuko()) return true;
 
                 //3 Combos Single Target

--- a/Magitek/Views/UserControls/Samurai/SingleTarget.xaml
+++ b/Magitek/Views/UserControls/Samurai/SingleTarget.xaml
@@ -31,6 +31,15 @@
                     <TextBlock Margin="0,0,10,0" Style="{DynamicResource TextBlockDefault}" Text="Filler Strategy:" />
                     <ComboBox Width="170" ItemsSource="{Binding Source={StaticResource SamuraiFillerStrategy}}" SelectedValue="{Binding SamuraiSettings.SamuraiFillerStrategy, Mode=TwoWay}" Style="{DynamicResource ComboBox}" />
                 </StackPanel>
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Margin="10,5,0,0" Style="{DynamicResource TextBlockDefault}" Text="GCD with Shifu: 2.15/2.14 => 2 GCD Filler" />
+                </StackPanel>
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Margin="10,0,0,0" Style="{DynamicResource TextBlockDefault}" Text="GCD with Shifu: 2.08/2.07/2.06 => 3 GCD Filler" />
+                </StackPanel>
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Margin="10,0,0,0" Style="{DynamicResource TextBlockDefault}" Text="GCD with Shifu: 2.01/2.00/1.99 => 4 GCD Filler" />
+                </StackPanel>
             </StackPanel>
         </controls:SettingsBlock>
 


### PR DESCRIPTION
- Fix MeikyoShisui at opener to not execute it manually
- Add more controls on AOE spells to not execute them on Single Target rotation
- Add more details in UI to find the right filler
- Rework a bit MeikyoShisui