### PR TITLE
Address a decision issue in Autonomous mode

### DIFF
--- a/Magitek/Extensions/SpellDataExtensions.cs
+++ b/Magitek/Extensions/SpellDataExtensions.cs
@@ -195,7 +195,10 @@ namespace Magitek.Extensions
             //    }
             //}
 
-            return Core.Me.HasAura(Auras.Swiftcast) || !MovementManager.IsMoving || spell.AdjustedCastTime <= TimeSpan.Zero;
+            if(!BotManager.Current.IsAutonomous) 
+                return Core.Me.HasAura(Auras.Swiftcast) || !MovementManager.IsMoving || spell.AdjustedCastTime <= TimeSpan.Zero;
+            //we don't care if the bot is moving in Autonomous mode, so we should always return true
+            return true;
         }
 
         public static bool CanCast(this SpellData spell, GameObject target)

--- a/Magitek/Extensions/SpellDataExtensions.cs
+++ b/Magitek/Extensions/SpellDataExtensions.cs
@@ -89,7 +89,7 @@ namespace Magitek.Extensions
                     Logger.WriteInfo($@"[Path] {sourceFilePath}");
                 }
             }
-            
+
             if (!GameSettingsManager.FaceTargetOnAction && BaseSettings.Instance.AssumeFaceTargetOnAction)
                 GameSettingsManager.FaceTargetOnAction = true;
 
@@ -152,13 +152,6 @@ namespace Magitek.Extensions
 
         private static bool Check(SpellData spell, GameObject target)
         {
-            // If we're using an autonomous bot base and we're running out of avoidance then don't cast
-            if (BotManager.Current.IsAutonomous)
-            {
-                if (AvoidanceManager.IsRunningOutOfAvoid && !(Core.Me.HasAura(Auras.Swiftcast) || spell.AdjustedCastTime <= TimeSpan.Zero))
-                    return false;
-            }
-
             if (target == null)
                 return false;
 
@@ -195,21 +188,32 @@ namespace Magitek.Extensions
             //    }
             //}
 
-            if(!BotManager.Current.IsAutonomous) 
-                return Core.Me.HasAura(Auras.Swiftcast) || !MovementManager.IsMoving || spell.AdjustedCastTime <= TimeSpan.Zero;
-            //we don't care if the bot is moving in Autonomous mode, so we should always return true
-            return true;
+            if (BotManager.Current.IsAutonomous)
+            {
+                // If we're using an autonomous bot base and we're running out of avoidance then don't cast
+                if (AvoidanceManager.IsRunningOutOfAvoid &&
+                    !(Core.Me.HasAura(Auras.Swiftcast) || spell.AdjustedCastTime <= TimeSpan.Zero))
+                {
+                    return false;
+                }
+
+                // See PR https://github.com/Exmortem/MagitekRoutine/pull/396
+                // we don't care if the bot is moving in Autonomous mode, so we should always return true
+                return true;
+            }
+
+            return Core.Me.HasAura(Auras.Swiftcast) || !MovementManager.IsMoving || spell.AdjustedCastTime <= TimeSpan.Zero;
         }
 
         public static bool CanCast(this SpellData spell, GameObject target)
         {
             if (!BaseSettings.Instance.UseCastOrQueue)
             {
-               return ActionManager.CanCast(spell, target);
+                return ActionManager.CanCast(spell, target);
             }
             else
             {
-               return ActionManager.CanCastOrQueue(spell, target);
+                return ActionManager.CanCastOrQueue(spell, target);
             }
         }
 
@@ -335,7 +339,7 @@ namespace Magitek.Extensions
             {
                 return spell.Cooldown.TotalMilliseconds <= 500;
             }
-            
+
         }
 
         public static bool IsKnownAndReady(this SpellData spell, int remainingTimeInMs = 0)


### PR DESCRIPTION
This should help with the issue where the bot keeps running after doing an avoid. 

Here is the logic sequence:

* Combat Handed off to Magitek
* Avoidance manager takes over (triggered by SideStep or w/e) Interupting an ability
* Avoidance concludes, but doesn't stop movement (we didn't make it out of the avoid, or in some cases, did make it out of the avoid but didn't stop) 
* Magitek (particularly casters) were stuck in a loop trying to cast but failing due to `IsMoving`.
* bot runs into wall (or w/e)

This change:

This change basically adjusts the return conditional to be true when autonomous. (Eg we don't care if we have swiftcast or are moving) and in autonomous mode we don't care about the adjust cast time. (TBH I think that can be removed).


I have tested against AST, and I haven't seen the issue re-appear. Going to be testing on CNJ again in a bit. 


---

TODO: 

Improvements still need to be made (especially to healers) for LOS checking of targets. I am not sure why, `CanCastOrQueue` is returning true, but going to cast the ability returns fails in some odd edge cases.