### PR TITLE
Grade 8 Potions + DNC improvement

### DIFF
--- a/Magitek/Enumerations/PotionEnum.cs
+++ b/Magitek/Enumerations/PotionEnum.cs
@@ -4,18 +4,22 @@
     {
         None = 0,
 
+        Dex_Grade_8 = 39728, 
         Dex_Grade_7 = 37841,
         Dex_Grade_6 = 36110,
         Dex_Grade_5 = 36105,
 
+        Intel_Grade_8 = 39730, 
         Intel_Grade_7 = 37843,
         Intel_Grade_6 = 36112,
         Intel_Grade_5 = 36107,
 
+        Mind_Grade_8 = 39731, 
         Mind_Grade_7 = 37844,
         Mind_Grade_6 = 36113,
         Mind_Grade_5 = 36108,
 
+        Strength_Grade_8 = 39727, 
         Strength_Grade_7 = 37840,
         Strength_Grade_6 = 36109,
         Strength_Grade_5 = 36104

--- a/Magitek/Gambits/Actions/DanceFinish.cs
+++ b/Magitek/Gambits/Actions/DanceFinish.cs
@@ -7,9 +7,9 @@ using System.Threading.Tasks;
 
 namespace Magitek.Gambits.Actions
 {
-    public class DanceStep : GambitAction
+    public class DanceFinish : GambitAction
     {
-        public DanceStep() : base(GambitActionTypes.DanceStep)
+        public DanceFinish() : base(GambitActionTypes.DanceFinish)
         {
         }
 

--- a/Magitek/Gambits/Actions/DanceStep.cs
+++ b/Magitek/Gambits/Actions/DanceStep.cs
@@ -7,9 +7,9 @@ using System.Threading.Tasks;
 
 namespace Magitek.Gambits.Actions
 {
-    public class DanceFinish : GambitAction
+    public class DanceStep : GambitAction
     {
-        public DanceFinish() : base(GambitActionTypes.DanceFinish)
+        public DanceStep() : base(GambitActionTypes.DanceStep)
         {
         }
 

--- a/Magitek/Logic/Astrologian/Buff.cs
+++ b/Magitek/Logic/Astrologian/Buff.cs
@@ -71,7 +71,7 @@ namespace Magitek.Logic.Astrologian
 
             // Added check to see if more than configured allies are around
 
-            var divinationTargets = Group.CastableAlliesWithin15.Count(r => r.IsAlive);
+            var divinationTargets = Group.CastableAlliesWithin30.Count(r => r.IsAlive);
 
             if (divinationTargets >= AstrologianSettings.Instance.DivinationAllies)
                 return await Spells.Divination.CastAura(Core.Me, Auras.Divination);

--- a/Magitek/Logic/Astrologian/Heals.cs
+++ b/Magitek/Logic/Astrologian/Heals.cs
@@ -573,13 +573,12 @@ namespace Magitek.Logic.Astrologian
                 return false;
 
             if (AstrologianSettings.Instance.FightLogic_CollectiveUnconscious && FightLogic.EnemyIsCastingAoe() &&
-                Group.CastableAlliesWithin15.Count(x => x.WithinSpellRange(Spells.CollectiveUnconscious.Radius)) >
-                AoeThreshold)
+                Group.CastableAlliesWithin30.Count(x => x.WithinSpellRange(Spells.CollectiveUnconscious.Radius)) > AoeThreshold)
                 return await FightLogic.DoAndBuffer(
                     Spells.CollectiveUnconscious.HealAura(Core.Me, Auras.CollectiveUnconsciousMitigation));
 
 
-            if (Group.CastableAlliesWithin10.Count(r => r.Distance() < 6
+            if (Group.CastableAlliesWithin30.Count(r => r.Distance() <= 30
                                                     && r.IsAlive
                                                     && r.CurrentHealthPercent <= AstrologianSettings.Instance.CollectiveUnconsciousHealth)
                                                     < AstrologianSettings.Instance.CollectiveUnconsciousAllies)

--- a/Magitek/Logic/Dancer/Aoe.cs
+++ b/Magitek/Logic/Dancer/Aoe.cs
@@ -12,9 +12,14 @@ namespace Magitek.Logic.Dancer
 {
     internal static class Aoe
     {
+
+        /*************************************************************************************
+         *                       AOE used in Single Target Rotation
+         * ***********************************************************************************/
         public static async Task<bool> StarfallDance()
         {
-            if (!DancerSettings.Instance.UseAoe) return false;
+            if (!DancerSettings.Instance.StarfallDance)
+                return false;
 
             if (Core.Me.ClassLevel < Spells.StarfallDance.LevelAcquired) return false;
 
@@ -31,7 +36,8 @@ namespace Magitek.Logic.Dancer
 
         public static async Task<bool> FanDance4()
         {
-            if (!DancerSettings.Instance.UseAoe) return false;
+            if (!DancerSettings.Instance.FanDance4)
+                return false;
 
             if (Core.Me.ClassLevel < Spells.FanDanceIV.LevelAcquired) return false;
 
@@ -48,7 +54,8 @@ namespace Magitek.Logic.Dancer
 
         public static async Task<bool> FanDance3()
         {
-            if (!DancerSettings.Instance.UseAoe) return false;
+            if (!DancerSettings.Instance.FanDance3)
+                return false;
 
             if (Core.Me.ClassLevel < Spells.FanDance3.LevelAcquired) return false;
 
@@ -59,6 +66,32 @@ namespace Magitek.Logic.Dancer
             return await Spells.FanDance3.Cast(Core.Me.CurrentTarget);
         }
 
+        public static async Task<bool> SaberDance()
+        {
+            if (!DancerSettings.Instance.SaberDance)
+                return false;
+
+            if (Core.Me.ClassLevel < Spells.SaberDance.LevelAcquired)
+                return false;
+
+            if (Core.Me.HasAura(Auras.StandardStep) || Core.Me.HasAura(Auras.TechnicalStep)) return false;
+
+            if (DancerSettings.Instance.UseRangeAndFacingChecks)
+                if (Core.Me.CurrentTarget.Distance(Core.Me) > Spells.SaberDance.Range) return false;
+
+            if (ActionResourceManager.Dancer.Esprit >= 85)
+                return await Spells.SaberDance.Cast(Core.Me.CurrentTarget);
+
+            if (!Core.Me.HasAura(Auras.TechnicalFinish))
+                return false;
+
+            return await Spells.SaberDance.Cast(Core.Me.CurrentTarget);
+        }
+
+
+        /*************************************************************************************
+         *                                       AOE
+         * ***********************************************************************************/
         public static async Task<bool> FanDance2()
         {
             if (!DancerSettings.Instance.UseAoe) return false;
@@ -104,26 +137,6 @@ namespace Magitek.Logic.Dancer
             if (!Core.Me.HasAura(Auras.FlourishingSymmetry) && !Core.Me.HasAura(Auras.SilkenSymmetry)) return false;
 
             return await Spells.RisingWindmill.Cast(Core.Me);
-        }
-
-        public static async Task<bool> SaberDance()
-        {
-            if (!DancerSettings.Instance.UseAoe) return false;
-
-            if (!DancerSettings.Instance.SaberDance) return false;
-
-            if (Core.Me.ClassLevel < Spells.SaberDance.LevelAcquired) return false;
-
-            if (ActionResourceManager.Dancer.Esprit < DancerSettings.Instance.SaberDanceEsprit) return false;
-
-            if (Core.Me.HasAura(Auras.StandardStep) || Core.Me.HasAura(Auras.TechnicalStep)) return false;
-
-            if (Combat.Enemies.Count(r => r.Distance(Core.Me.CurrentTarget) <= 5 + r.CombatReach) < DancerSettings.Instance.SaberDanceEnemies) return false;
-
-            if (DancerSettings.Instance.UseRangeAndFacingChecks)
-                if (Core.Me.CurrentTarget.Distance(Core.Me) > Spells.SaberDance.Range) return false;
-
-            return await Spells.SaberDance.Cast(Core.Me.CurrentTarget);
         }
 
         public static async Task<bool> Bladeshower()

--- a/Magitek/Logic/Dancer/Buff.cs
+++ b/Magitek/Logic/Dancer/Buff.cs
@@ -34,12 +34,6 @@ namespace Magitek.Logic.Dancer
             if (Core.Me.HasAura(Auras.StandardStep) || Core.Me.HasAura(Auras.TechnicalStep))
                 return false;
 
-            if (DancerSettings.Instance.DontDotIfCurrentTargetIsDyingSoon && Core.Me.CurrentTarget.CombatTimeLeft() <= DancerSettings.Instance.DontDotIfCurrentTargetIsDyingWithinXSeconds)
-                return false;
-
-            if (DancerSettings.Instance.DevilmentWithFlourish && !Spells.Flourish.IsKnownAndReady())
-                return false;
-
             return await Spells.Devilment.Cast(Core.Me);
         }
 

--- a/Magitek/Logic/Dancer/Dances.cs
+++ b/Magitek/Logic/Dancer/Dances.cs
@@ -39,7 +39,7 @@ namespace Magitek.Logic.Dancer
 
             if (Core.Me.HasAura(Auras.TechnicalFinish, true) && !Core.Me.HasAura(Auras.TechnicalFinish, true, 4000)) return false;
 
-            if (DancerSettings.Instance.DontDotIfCurrentTargetIsDyingSoon && Core.Me.CurrentTarget.CombatTimeLeft() <= DancerSettings.Instance.DontDotIfCurrentTargetIsDyingWithinXSeconds)
+            if (DancerSettings.Instance.DontDanceIfCurrentTargetIsDyingSoon && Core.Me.CurrentTarget.CombatTimeLeft() <= DancerSettings.Instance.DontDanceIfCurrentTargetIsDyingWithinXSeconds)
                 return false;
 
             var procs = Core.Me.Auras.AuraList.Where(x => x.Caster == Core.Me && (
@@ -74,7 +74,7 @@ namespace Magitek.Logic.Dancer
             if (!Core.Me.HasAura(Auras.StandardFinish))
                 return false;
 
-            if (DancerSettings.Instance.DontDotIfCurrentTargetIsDyingSoon && Core.Me.CurrentTarget.CombatTimeLeft() <= DancerSettings.Instance.DontDotIfCurrentTargetIsDyingWithinXSeconds)
+            if (DancerSettings.Instance.DontDanceIfCurrentTargetIsDyingSoon && Core.Me.CurrentTarget.CombatTimeLeft() <= DancerSettings.Instance.DontDanceIfCurrentTargetIsDyingWithinXSeconds)
                 return false;
 
             if (DancerSettings.Instance.DevilmentWithTechnicalStep && !Core.Me.HasAura(Auras.Devilment))
@@ -98,7 +98,7 @@ namespace Magitek.Logic.Dancer
             return await Spells.TechnicalStep.Cast(Core.Me);
         }
 
-        public static async Task<bool> DanceFinish() // Just for Gambit Readablity
+        public static async Task<bool> DanceFinish() // Just for Gambit Readability
         {
             return await DanceStep();
         }
@@ -111,18 +111,15 @@ namespace Magitek.Logic.Dancer
 
             if (Casting.LastSpell == Spells.QuadrupleTechnicalFinish) return false;
 
-            if (DancerSettings.Instance.UseRangeAndFacingChecks)
-            {
-                if (Core.Me.CurrentTarget.Distance(Core.Me) > (15 + Core.Me.CurrentTarget.CombatReach))
-                    return false;
-            }
-
             try
             {
-                Logger.Write($@"[Magitek] Dance Log {ActionResourceManager.Dancer.CurrentStep}");
+                Logger.Write($@"[Magitek] Current Step Dance To execute {ActionResourceManager.Dancer.CurrentStep}");
                 switch (ActionResourceManager.Dancer.CurrentStep)
                 {
                     case ActionResourceManager.Dancer.DanceStep.Finish:
+                        if (DancerSettings.Instance.OnlyFinishStepInRange && Core.Me.CurrentTarget.Distance(Core.Me) > 15 + Core.Me.CurrentTarget.CombatReach)
+                            return false;
+
                         if (Core.Me.HasAura(Auras.StandardStep))
                             return await Spells.DoubleStandardFinish.Cast(Core.Me);
                         else if (Core.Me.HasAura(Auras.TechnicalStep))

--- a/Magitek/Logic/Dancer/SingleTarget.cs
+++ b/Magitek/Logic/Dancer/SingleTarget.cs
@@ -13,6 +13,9 @@ namespace Magitek.Logic.Dancer
 
         public static async Task<bool> FanDance()
         {
+            if (!DancerSettings.Instance.FanDance1)
+                return false;
+
             if (ActionResourceManager.Dancer.FourFoldFeathers < 4 && !Core.Me.HasAura(Auras.Devilment) && Core.Me.ClassLevel >= 62) return false;
 
             if (Combat.Enemies.Count(r => r.Distance(Core.Me) <= 5 + r.CombatReach) >= DancerSettings.Instance.FanDanceTwoEnemies) return false;

--- a/Magitek/Logic/Paladin/Defensive.cs
+++ b/Magitek/Logic/Paladin/Defensive.cs
@@ -138,7 +138,7 @@ namespace Magitek.Logic.Paladin
             if (!Globals.InParty)
                 return false;
 
-            if (!Group.CastableAlliesWithin15.Any(r => r.CurrentHealthPercent < PaladinSettings.Instance.DivineVeilHp))
+            if (!Group.CastableAlliesWithin30.Any(r => r.CurrentHealthPercent < PaladinSettings.Instance.DivineVeilHp))
                 return false;
 
             if (!Group.CastableAlliesWithin30.Any(r => r.IsHealer()))

--- a/Magitek/Logic/Reaper/Normal/Cooldown.cs
+++ b/Magitek/Logic/Reaper/Normal/Cooldown.cs
@@ -60,7 +60,7 @@ namespace Magitek.Logic.Reaper
 
             if (Globals.InParty)
             {
-                var couldArcane = Group.CastableAlliesWithin15.Count(r => !r.HasAura(Auras.ArcaneCircle));
+                var couldArcane = Group.CastableAlliesWithin30.Count(r => !r.HasAura(Auras.ArcaneCircle));
                 var arcaneNeededCount = ReaperSettings.Instance.ArcaneCircleCount;
 
                 if (ReaperSettings.Instance.ArcaneCircleEntireParty)

--- a/Magitek/Logic/Sage/Heal.cs
+++ b/Magitek/Logic/Sage/Heal.cs
@@ -260,9 +260,10 @@ namespace Magitek.Logic.Sage
             if (!spell.IsKnownAndReady())
                 return false;
 
-            var targets = Group.CastableAlliesWithin15.Where(r => r.CurrentHealthPercent <= SageSettings.Instance.PhysisHpPercent
-                                                             && !r.HasAura(aura));
-
+            var targets = Spells.PhysisII.IsKnown()
+                ? Group.CastableAlliesWithin30.Where(r => r.CurrentHealthPercent <= SageSettings.Instance.PhysisHpPercent && !r.HasAura(aura))
+                : Group.CastableAlliesWithin15.Where(r => r.CurrentHealthPercent <= SageSettings.Instance.PhysisHpPercent && !r.HasAura(aura));
+        
             if (targets.Count() < AoeNeedHealing)
                 return false;
 
@@ -511,7 +512,7 @@ namespace Magitek.Logic.Sage
                 if (SageSettings.Instance.FightLogic_Panhaima && FightLogic.EnemyHasAnyAoeLogic())
                     return false;
 
-                var targets = Group.CastableAlliesWithin15.Where(CanPanhaima);
+                var targets = Group.CastableAlliesWithin30.Where(CanPanhaima);
 
                 if (targets.Count() < AoeNeedHealing)
                     return false;
@@ -684,12 +685,12 @@ namespace Magitek.Logic.Sage
 
             if (Globals.InParty)
             {
-                var targets = Group.CastableAlliesWithin15.Where(CanKerachole).ToList();
+                var targets = Group.CastableAlliesWithin30.Where(CanKerachole).ToList();
 
                 if (targets.Count < AoeNeedHealing)
                     return false;
 
-                if (SageSettings.Instance.KeracholeOnlyWithTank && !Group.CastableAlliesWithin15.Any(r => r.IsTank(SageSettings.Instance.KeracholeOnlyWithMainTank)))
+                if (SageSettings.Instance.KeracholeOnlyWithTank && !Group.CastableAlliesWithin30.Any(r => r.IsTank(SageSettings.Instance.KeracholeOnlyWithMainTank)))
                     return false;
 
                 if (!UseAoEHealingBuff(targets))
@@ -714,7 +715,7 @@ namespace Magitek.Logic.Sage
                 if (unit.HasAura(Auras.Kerachole))
                     return false;
 
-                return unit.Distance(Core.Me) <= 15;
+                return unit.Distance(Core.Me) <= Spells.Kerachole.Radius;
             }
         }
         public static async Task<bool> Holos()
@@ -734,7 +735,7 @@ namespace Magitek.Logic.Sage
             if (!Spells.Holos.IsKnownAndReady())
                 return false;
 
-            var targets = Group.CastableAlliesWithin15.Where(r => r.CurrentHealthPercent <= SageSettings.Instance.HolosHealthPercent
+            var targets = Group.CastableAlliesWithin30.Where(r => r.CurrentHealthPercent <= SageSettings.Instance.HolosHealthPercent
                                                              && !r.HasAura(Auras.Holos));
 
             if (targets.Count() < AoeNeedHealing)

--- a/Magitek/Logic/Samurai/Aoe.cs
+++ b/Magitek/Logic/Samurai/Aoe.cs
@@ -154,7 +154,7 @@ namespace Magitek.Logic.Samurai
             if (SamuraiRoutine.SenCount != 2)
                 return false;
 
-            if (SamuraiRoutine.AoeEnemies5Yards < SamuraiSettings.Instance.AoeEnemies)
+            if (SamuraiRoutine.AoeEnemies8Yards < SamuraiSettings.Instance.AoeEnemies)
                 return false;
 
             await Spells.TenkaGoken.Cast(Core.Me.CurrentTarget);

--- a/Magitek/Logic/WhiteMage/Buff.cs
+++ b/Magitek/Logic/WhiteMage/Buff.cs
@@ -157,7 +157,7 @@ namespace Magitek.Logic.WhiteMage
             if (Casting.LastSpell == Spells.AfflatusRapture)
                 return false;
 
-            var temperance = Group.CastableAlliesWithin30.Count(r => r.CurrentHealth > 0 && r.Distance(Core.Me) <= 15 && r.CurrentHealthPercent <= WhiteMageSettings.Instance.TemperanceHealthPercent);
+            var temperance = Group.CastableAlliesWithin50.Count(r => r.CurrentHealth > 0 && r.Distance(Core.Me) <= 50 && r.CurrentHealthPercent <= WhiteMageSettings.Instance.TemperanceHealthPercent);
 
             if (temperance < WhiteMageSettings.Instance.TemperanceAllies)
                 return false;

--- a/Magitek/Logic/WhiteMage/Heal.cs
+++ b/Magitek/Logic/WhiteMage/Heal.cs
@@ -338,7 +338,7 @@ namespace Magitek.Logic.WhiteMage
 
             var asylumTarget = Group.CastableTanks.FirstOrDefault(r => r.CurrentHealth > 0 &&
                                                                        r.CurrentHealthPercent <= WhiteMageSettings.Instance.AsylumHealthPercent &&
-                                                                       Group.CastableAlliesWithin30.Count(x => x.CurrentHealth > 0 && x.Distance(r) <= 7 && x.CurrentHealthPercent <= WhiteMageSettings.Instance.AsylumHealthPercent) >= WhiteMageSettings.Instance.AsylumAllies - 1);
+                                                                       Group.CastableAlliesWithin30.Count(x => x.CurrentHealth > 0 && x.Distance(r) <= 15 && x.CurrentHealthPercent <= WhiteMageSettings.Instance.AsylumHealthPercent) >= WhiteMageSettings.Instance.AsylumAllies - 1);
 
             if (asylumTarget == null)
                 return false;

--- a/Magitek/Magitek.csproj
+++ b/Magitek/Magitek.csproj
@@ -195,8 +195,8 @@
     <Compile Include="Gambits\Actions\CastSpellOnCurrentTargetAction.cs" />
     <Compile Include="Gambits\Actions\CastSpellOnEnemyAction.cs" />
     <Compile Include="Gambits\Actions\CastSpellOnFriendlyNpcAction.cs" />
-    <Compile Include="Gambits\Actions\DanceFinish.cs" />
     <Compile Include="Gambits\Actions\DanceStep.cs" />
+    <Compile Include="Gambits\Actions\DanceFinish.cs" />
     <Compile Include="Gambits\Actions\CastSpellOnSelfAction.cs" />
     <Compile Include="Gambits\Actions\GambitAction.cs" />
     <Compile Include="Gambits\Actions\IGambitAction.cs" />

--- a/Magitek/Models/Dancer/DancerSettings.cs
+++ b/Magitek/Models/Dancer/DancerSettings.cs
@@ -13,10 +13,7 @@ namespace Magitek.Models.Dancer
 
         public static DancerSettings Instance { get; set; } = new DancerSettings();
 
-        [Setting]
-        [DefaultValue(true)]
-        public bool UseRangeAndFacingChecks { get; set; }
-
+        #region buff
         [Setting]
         [DefaultValue(true)]
         public bool UseDevilment { get; set; }
@@ -31,20 +28,10 @@ namespace Magitek.Models.Dancer
 
         [Setting]
         [DefaultValue(true)]
-        public bool UseCuringWaltz { get; set; }
-
-        [Setting]
-        [DefaultValue(80f)]
-        public float CuringWaltzHP { get; set; }
-
-        [Setting]
-        [DefaultValue(2)]
-        public int CuringWaltzCount { get; set; }
-
-        [Setting]
-        [DefaultValue(true)]
         public bool UseFlourish { get; set; }
+        #endregion
 
+        #region singletarget
         [Setting]
         [DefaultValue(true)]
         public bool UseStandardStep { get; set; }
@@ -53,6 +40,32 @@ namespace Magitek.Models.Dancer
         [DefaultValue(true)]
         public bool UseTechnicalStep { get; set; }
 
+        [Setting]
+        [DefaultValue(true)]
+        public bool OnlyFinishStepInRange { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
+        public bool FanDance1 { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
+        public bool StarfallDance { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
+        public bool FanDance3 { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
+        public bool FanDance4 { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
+        public bool SaberDance { get; set; }
+        #endregion
+
+        #region aoe
         [Setting]
         [DefaultValue(true)]
         public bool UseAoe { get; set; }
@@ -96,23 +109,33 @@ namespace Magitek.Models.Dancer
         [Setting]
         [DefaultValue(2)]
         public int FanDanceTwoEnemies { get; set; }
+        #endregion
+
+        #region utility
+        [Setting]
+        [DefaultValue(true)]
+        public bool UseRangeAndFacingChecks { get; set; }
+
+
 
         [Setting]
         [DefaultValue(true)]
-        public bool SaberDance { get; set; }
+        public bool UseCuringWaltz { get; set; }
 
         [Setting]
-        [DefaultValue(1)]
-        public int SaberDanceEnemies { get; set; }
+        [DefaultValue(80f)]
+        public float CuringWaltzHP { get; set; }
 
         [Setting]
-        [DefaultValue(50)]
-        public int SaberDanceEsprit { get; set; }
+        [DefaultValue(2)]
+        public int CuringWaltzCount { get; set; }
 
         [Setting]
         [DefaultValue(true)]
         public bool UseImprovisation { get; set; }
+        #endregion
 
+        #region partner
         [Setting]
         [DefaultValue(true)]
         public bool UseClosedPosition { get; set; }
@@ -122,20 +145,9 @@ namespace Magitek.Models.Dancer
         public bool DancePartnerChocobo { get; set; }
 
         [Setting]
-        [DefaultValue(false)]
-        public bool DontDotIfCurrentTargetIsDyingSoon { get; set; }
-
-        [Setting]
-        [DefaultValue(20)]
-        public int DontDotIfCurrentTargetIsDyingWithinXSeconds { get; set; }
-
-        [Setting]
-        [DefaultValue(true)]
-        public bool OnlyFinishStepInRange { get; set; }
-
-        [Setting]
         [DefaultValue(DancePartnerStrategy.ClosestDps)]
         public DancePartnerStrategy SelectedStrategy { get; set; }
+        #endregion
 
         #region Partner Weights
 
@@ -326,5 +338,14 @@ namespace Magitek.Models.Dancer
         [DefaultValue(19)]
         public int Pvp_SagPartnerWeight { get; set; }
         #endregion
+
+        [Setting]
+        [DefaultValue(false)]
+        public bool DontDanceIfCurrentTargetIsDyingSoon { get; set; }
+
+        [Setting]
+        [DefaultValue(10)]
+        public int DontDanceIfCurrentTargetIsDyingWithinXSeconds { get; set; }
+
     }
 }

--- a/Magitek/Resources/Toggles/DancerToggles.json
+++ b/Magitek/Resources/Toggles/DancerToggles.json
@@ -192,6 +192,74 @@
     "ToggleModifierKey": 0
   },
   {
+    "ToggleText": "Fan Dance 1 3 4",
+    "ToggleJob": "Dancer",
+    "ToggleShowOnOverlay": true,
+    "IsPvpToggle": false,
+    "ToggleChecked": true,
+    "Settings": [
+      {
+        "Name": "FanDance3",
+        "Type": 1,
+        "BoolCheckedValue": true,
+        "BoolUncheckedValue": false,
+        "IntCheckedValue": 0,
+        "IntUncheckedValue": 0,
+        "FloatCheckedValue": 0.0,
+        "FloatUncheckedValue": 0.0
+      },
+      {
+        "Name": "FanDance4",
+        "Type": 1,
+        "BoolCheckedValue": true,
+        "BoolUncheckedValue": false,
+        "IntCheckedValue": 0,
+        "IntUncheckedValue": 0,
+        "FloatCheckedValue": 0.0,
+        "FloatUncheckedValue": 0.0
+      },
+      {
+        "Name": "FanDance1",
+        "Type": 1,
+        "BoolCheckedValue": true,
+        "BoolUncheckedValue": false,
+        "IntCheckedValue": 0,
+        "IntUncheckedValue": 0,
+        "FloatCheckedValue": 0.0,
+        "FloatUncheckedValue": 0.0
+      }
+    ],
+    "ExecuteToggleCommand": {},
+    "AddToggleSettingCommand": {},
+    "RemoveToggleSettingCommand": {},
+    "ToggleKey": 0,
+    "ToggleModifierKey": 0
+  },
+  {
+    "ToggleText": "Starfall Dance",
+    "ToggleJob": "Dancer",
+    "ToggleShowOnOverlay": true,
+    "IsPvpToggle": false,
+    "ToggleChecked": true,
+    "Settings": [
+      {
+        "Name": "StarfallDance",
+        "Type": 1,
+        "BoolCheckedValue": true,
+        "BoolUncheckedValue": false,
+        "IntCheckedValue": 0,
+        "IntUncheckedValue": 0,
+        "FloatCheckedValue": 0.0,
+        "FloatUncheckedValue": 0.0
+      }
+    ],
+    "ExecuteToggleCommand": {},
+    "AddToggleSettingCommand": {},
+    "RemoveToggleSettingCommand": {},
+    "ToggleKey": 0,
+    "ToggleModifierKey": 0
+  },
+  {
     "ToggleText": "ClosedPosition",
     "ToggleJob": "Dancer",
     "ToggleShowOnOverlay": true,
@@ -216,7 +284,7 @@
     "ToggleModifierKey": 0
   },
   {
-    "ToggleText": "CurringWaltz",
+    "ToggleText": "Heal",
     "ToggleJob": "Dancer",
     "ToggleShowOnOverlay": true,
     "IsPvpToggle": false,
@@ -224,6 +292,16 @@
     "Settings": [
       {
         "Name": "UseCuringWaltz",
+        "Type": 1,
+        "BoolCheckedValue": true,
+        "BoolUncheckedValue": false,
+        "IntCheckedValue": 0,
+        "IntUncheckedValue": 0,
+        "FloatCheckedValue": 0.0,
+        "FloatUncheckedValue": 0.0
+      },
+      {
+        "Name": "UseImprovisation",
         "Type": 1,
         "BoolCheckedValue": true,
         "BoolUncheckedValue": false,

--- a/Magitek/Rotations/Dancer.cs
+++ b/Magitek/Rotations/Dancer.cs
@@ -105,40 +105,47 @@ namespace Magitek.Rotations
             //LimitBreak
             if (Aoe.ForceLimitBreak()) return true;
 
+            //Buff Partner
             if (await Buff.DancePartner()) return true;
 
-            if (await Aoe.StarfallDance()) return true;
-            if (await Dances.Tillana()) return true;
+            // Dance
+            if (await Dances.DanceStep()) return true;
             if (await Dances.StandardStep()) return true;
             if (await Dances.TechnicalStep()) return true;
-            if (await Dances.DanceStep()) return true;
 
             if (Core.Me.HasAura(Auras.StandardStep) || Core.Me.HasAura(Auras.TechnicalStep))
                 return false;
 
             if (DancerRoutine.GlobalCooldown.CanWeave())
             {
+                //utility
                 if (await PhysicalDps.Interrupt(DancerSettings.Instance)) return true;
                 if (await PhysicalDps.SecondWind(DancerSettings.Instance)) return true;
                 if (await Buff.UsePotion()) return true;
-
-
-                if (await Buff.CuringWaltz()) return true;
+                
+                //Buff
                 if (await Buff.PreTechnicalDevilment()) return true;
+                if (await Buff.Devilment()) return true;
+                if (await Buff.Flourish()) return true;
+
+                //OGCD
                 if (await Aoe.FanDance4()) return true;
                 if (await Aoe.FanDance3()) return true;
                 if (await Aoe.FanDance2()) return true;
                 if (await SingleTarget.FanDance()) return true;
-                if (await Buff.Devilment()) return true;
-                if (await Buff.Flourish()) return true;
+
+                //Heal
+                if (await Buff.CuringWaltz()) return true;
                 if (await Buff.Improvisation()) return true;
             }
 
+            if (await Aoe.StarfallDance()) return true;
+            if (await Dances.Tillana()) return true;
+            if (await SingleTarget.Fountainfall()) return true;
+            if (await SingleTarget.ReverseCascade()) return true; 
             if (await Aoe.SaberDance()) return true;
             if (await Aoe.Bloodshower()) return true;
             if (await Aoe.RisingWindmill()) return true;
-            if (await SingleTarget.Fountainfall()) return true;
-            if (await SingleTarget.ReverseCascade()) return true;
             if (await Aoe.Bladeshower()) return true;
             if (await Aoe.Windmill()) return true;
             if (await SingleTarget.Fountain()) return true;

--- a/Magitek/Utilities/Group.cs
+++ b/Magitek/Utilities/Group.cs
@@ -203,6 +203,7 @@ namespace Magitek.Utilities
                 CastableDps.Add(ally);
 
             var distance = ally.Distance(Core.Me);
+            if (distance <= 50) { CastableAlliesWithin50.Add(ally); }
             if (distance <= 30) { CastableAlliesWithin30.Add(ally); }
             if (distance <= 25) { CastableAlliesWithin25.Add(ally); }
             if (distance <= 20) { CastableAlliesWithin20.Add(ally); }
@@ -217,6 +218,7 @@ namespace Magitek.Utilities
             CastableTanks.Clear();
             CastableHealers.Clear();
             CastableDps.Clear();
+            CastableAlliesWithin50.Clear();
             CastableAlliesWithin30.Clear();
             CastableAlliesWithin25.Clear();
             CastableAlliesWithin20.Clear();
@@ -230,6 +232,7 @@ namespace Magitek.Utilities
         public static readonly List<Character> CastableTanks = new List<Character>();
         public static readonly List<Character> CastableHealers = new List<Character>();
         public static readonly List<Character> CastableDps = new List<Character>();
+        public static readonly List<Character> CastableAlliesWithin50 = new List<Character>();
         public static readonly List<Character> CastableAlliesWithin30 = new List<Character>();
         public static readonly List<Character> CastableAlliesWithin25 = new List<Character>();
         public static readonly List<Character> CastableAlliesWithin20 = new List<Character>();

--- a/Magitek/Views/UserControls/Dancer/Aoe.xaml
+++ b/Magitek/Views/UserControls/Dancer/Aoe.xaml
@@ -96,23 +96,6 @@
                                   Value="{Binding DancerSettings.FanDanceTwoEnemies, Mode=TwoWay}" />
                 <TextBlock Grid.Row="5" Grid.Column="3" Style="{DynamicResource TextBlockDefault}" Text=" Enemies" />
 
-                <CheckBox Grid.Row="6" Grid.Column="0" Content="Saber Dance " IsChecked="{Binding DancerSettings.SaberDance, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                <TextBlock Grid.Row="6" Grid.Column="1" Style="{DynamicResource TextBlockDefault}" Text="When There Are " />
-                <controls:Numeric Grid.Row="6"
-                                  Grid.Column="2"
-                                  Margin="0,3,0,0"
-                                  MaxValue="100"
-                                  MinValue="1"
-                                  Value="{Binding DancerSettings.SaberDanceEnemies, Mode=TwoWay}" />
-                <TextBlock Grid.Row="6" Grid.Column="3" Style="{DynamicResource TextBlockDefault}" Text=" Enemies and with at least " />
-                <controls:Numeric Grid.Row="6"
-                                  Grid.Column="4"
-                                  Margin="0,3,0,0"
-                                  MaxValue="100"
-                                  MinValue="50"
-                                  Value="{Binding DancerSettings.SaberDanceEsprit, Mode=TwoWay}" />
-                <TextBlock Grid.Row="6" Grid.Column="5" Style="{DynamicResource TextBlockDefault}" Text=" Esprit" />
-
             </Grid>
         </controls:SettingsBlock>
 

--- a/Magitek/Views/UserControls/Dancer/Buffs.xaml
+++ b/Magitek/Views/UserControls/Dancer/Buffs.xaml
@@ -7,8 +7,8 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:sys="clr-namespace:System;assembly=mscorlib"
              xmlns:viewModels="clr-namespace:Magitek.ViewModels"
-             d:DesignHeight="420.513"
-             d:DesignWidth="500"
+             d:DesignHeight="500"
+             d:DesignWidth="800"
              mc:Ignorable="d">
 
     <UserControl.DataContext>
@@ -52,151 +52,149 @@
 
         <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
             <StackPanel Margin="5">
+                <TextBlock Style="{DynamicResource TextBlockDefault}" Text="DPS :" />
                 <StackPanel Orientation="Horizontal">
-                    <CheckBox Content="Use Flourish" IsChecked="{Binding DancerSettings.UseFlourish, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <CheckBox Margin="5" Content="Use Flourish" IsChecked="{Binding DancerSettings.UseFlourish, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                </StackPanel>
+                <StackPanel Orientation="Horizontal">
+                    <CheckBox Margin="5" Content="Use Devilment    " IsChecked="{Binding DancerSettings.UseDevilment, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <RadioButton Margin="5" Foreground="White" Content="With Flourish        " GroupName="DevilmentStrategy" IsChecked="{Binding DancerSettings.DevilmentWithFlourish, Mode=TwoWay}" />
+                    <RadioButton Margin="5" Foreground="White" Content="Before Technical Step" GroupName="DevilmentStrategy" IsChecked="{Binding DancerSettings.DevilmentWithTechnicalStep, Mode=TwoWay}" />
                 </StackPanel>
             </StackPanel>
         </controls:SettingsBlock>
 
-        <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
-            <StackPanel Margin="5">
-                <StackPanel Orientation="Horizontal">
-                    <CheckBox Content="Use Devilment    " IsChecked="{Binding DancerSettings.UseDevilment, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                    <RadioButton Foreground="White" Content="With Flourish        " GroupName="DevilmentStrategy" IsChecked="{Binding DancerSettings.DevilmentWithFlourish, Mode=TwoWay}" />
-                    <RadioButton Foreground="White" Content="Before Technical Step" GroupName="DevilmentStrategy" IsChecked="{Binding DancerSettings.DevilmentWithTechnicalStep, Mode=TwoWay}" />
-                </StackPanel>
-            </StackPanel>
-        </controls:SettingsBlock>
-
-        <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
-            <StackPanel Margin="5">
-                <StackPanel Orientation="Horizontal">
-                    <CheckBox Content="Use Improvisation    " IsChecked="{Binding DancerSettings.UseImprovisation, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                </StackPanel>
-            </StackPanel>
-        </controls:SettingsBlock>
-
-        <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
-            <Grid Margin="5">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="112" />
-                    <ColumnDefinition Width="Auto" />
-                    <ColumnDefinition Width="Auto" />
-                    <ColumnDefinition Width="Auto" />
-                    <ColumnDefinition Width="Auto" />
-                    <ColumnDefinition Width="Auto" />
-                </Grid.ColumnDefinitions>
-
-                <CheckBox Grid.Column="0" Content="Curing Waltz" IsChecked="{Binding DancerSettings.UseCuringWaltz, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                <controls:Numeric Grid.Column="1" MaxValue="100" MinValue="1" Value="{Binding DancerSettings.CuringWaltzHP, Mode=TwoWay}" />
-                <TextBlock Grid.Column="2" Margin="2,0,3,0" Style="{DynamicResource TextBlockDefault}" Text="Health Percent When" />
-                <controls:Numeric Grid.Column="3" MaxValue="30" MinValue="1" Value="{Binding DancerSettings.CuringWaltzCount, Mode=TwoWay}" />
-                <TextBlock Grid.Column="4" Margin="2,0,3,0" Style="{DynamicResource TextBlockDefault}" Text=" Allies Need Healing" />
-            </Grid>
-        </controls:SettingsBlock>
-
-        <controls:SettingsBlock Background="{DynamicResource ClassSelectorBackground}">
-            <StackPanel Margin="5">
-                <CheckBox Content=" Use Closed Position" IsChecked="{Binding DancerSettings.UseClosedPosition, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-            </StackPanel>
-        </controls:SettingsBlock>
-
-        <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
-            <StackPanel Margin="5">
-                <StackPanel Orientation="Horizontal">
-                    <CheckBox Content="Dance Partner Chocobo" IsChecked="{Binding DancerSettings.DancePartnerChocobo, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                </StackPanel>
-            </StackPanel>
-        </controls:SettingsBlock>
         
         <controls:SettingsBlock Background="{DynamicResource ClassSelectorBackground}">
-            <Grid Margin="5">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto" />
-                    <ColumnDefinition Width="Auto" />
-                    <ColumnDefinition Width="Auto" />
-                </Grid.ColumnDefinitions>
-                <Grid.RowDefinitions>
-                    <RowDefinition />
-                    <RowDefinition />
-                </Grid.RowDefinitions>
-                <StackPanel Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3" Orientation="Horizontal">
-                    <TextBlock Margin="0,0,10,0" Style="{DynamicResource TextBlockDefault}" Text="Dance With:" />
-                    <ComboBox Width="100" ItemsSource="{Binding Source={StaticResource DancePartner}}" SelectedValue="{Binding DancerSettings.SelectedStrategy, Mode=TwoWay}" Style="{DynamicResource ComboBox}" />
+            <StackPanel Margin="5">
+                <TextBlock Style="{DynamicResource TextBlockDefault}" Text="Partner :" />
+                <StackPanel Orientation="Horizontal">
+                    <CheckBox Margin="5" Content="Use Closed Position" IsChecked="{Binding DancerSettings.UseClosedPosition, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                 </StackPanel>
-                <controls:SettingsBlock Grid.Row="1" Background="{DynamicResource ClassSelectorBackground}">
+                <StackPanel Orientation="Horizontal" Margin="15 5 0 0">
+                    <CheckBox Content="Select Chocobo as partner" IsChecked="{Binding DancerSettings.DancePartnerChocobo, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                </StackPanel>
+                <StackPanel Orientation="Horizontal">
                     <Grid Margin="5">
-                        <Grid.RowDefinitions>
-                            <RowDefinition />
-                            <RowDefinition />
-                            <RowDefinition />
-                            <RowDefinition />
-                            <RowDefinition />
-                            <RowDefinition />
-                            <RowDefinition />
-                            <RowDefinition />
-                        </Grid.RowDefinitions>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto" />
                             <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="30" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition />
+                            <RowDefinition />
+                        </Grid.RowDefinitions>
+                        <StackPanel Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3" Orientation="Horizontal">
+                            <TextBlock Margin="5,10,10,0" Style="{DynamicResource TextBlockDefault}" Text="Dance With:" />
+                            <ComboBox Margin="0,10,10,0" Width="100" ItemsSource="{Binding Source={StaticResource DancePartner}}" SelectedValue="{Binding DancerSettings.SelectedStrategy, Mode=TwoWay}" Style="{DynamicResource ComboBox}" />
+                        </StackPanel>
+                        <controls:SettingsBlock Grid.Row="1" Background="{DynamicResource ClassSelectorBackground}">
+                            <Grid Margin="5">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition />
+                                    <RowDefinition />
+                                    <RowDefinition />
+                                    <RowDefinition />
+                                    <RowDefinition />
+                                    <RowDefinition />
+                                    <RowDefinition />
+                                    <RowDefinition />
+                                </Grid.RowDefinitions>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="30" />
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="30" />
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="30" />
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="30" />
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="30" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+
+                                <TextBlock Grid.Row="1" Grid.Column="0" Style="{DynamicResource TextBlockDefault}" Text="MNK: " />
+                                <controls:Numeric Grid.Row="1" Grid.Column="1" Margin="0,3,0,0" MaxValue="100" MinValue="1" Value="{Binding DancerSettings.MnkPartnerWeight, Mode=TwoWay}" />
+                                <TextBlock Grid.Row="1" Grid.Column="3" Style="{DynamicResource TextBlockDefault}" Text="DRG: " />
+                                <controls:Numeric Grid.Row="1" Grid.Column="4" Margin="0,3,0,0" MaxValue="100" MinValue="1" Value="{Binding DancerSettings.DrgPartnerWeight, Mode=TwoWay}" />
+                                <TextBlock Grid.Row="1" Grid.Column="6" Style="{DynamicResource TextBlockDefault}" Text="NIN: " />
+                                <controls:Numeric Grid.Row="1" Grid.Column="7" Margin="0,3,0,0" MaxValue="100" MinValue="1" Value="{Binding DancerSettings.NinPartnerWeight, Mode=TwoWay}" />
+                                <TextBlock Grid.Row="1" Grid.Column="9" Style="{DynamicResource TextBlockDefault}" Text="SAM: " />
+                                <controls:Numeric Grid.Row="1" Grid.Column="10" Margin="0,3,0,0" MaxValue="100" MinValue="1" Value="{Binding DancerSettings.SamPartnerWeight, Mode=TwoWay}" />
+                                <TextBlock Grid.Row="1" Grid.Column="12" Style="{DynamicResource TextBlockDefault}" Text="RPR: " />
+                                <controls:Numeric Grid.Row="1" Grid.Column="13" Margin="0,3,0,0" MaxValue="100" MinValue="1" Value="{Binding DancerSettings.RprPartnerWeight, Mode=TwoWay}" />
+
+                                <TextBlock Grid.Row="2" Grid.Column="0" Style="{DynamicResource TextBlockDefault}" Text="BLM: " />
+                                <controls:Numeric Grid.Row="2" Grid.Column="1" Margin="0,3,0,0" MaxValue="100" MinValue="1" Value="{Binding DancerSettings.BlmPartnerWeight, Mode=TwoWay}" />
+                                <TextBlock Grid.Row="2" Grid.Column="3" Style="{DynamicResource TextBlockDefault}" Text="SMN: " />
+                                <controls:Numeric Grid.Row="2" Grid.Column="4" Margin="0,3,0,0" MaxValue="100" MinValue="1" Value="{Binding DancerSettings.SmnPartnerWeight, Mode=TwoWay}" />
+                                <TextBlock Grid.Row="2" Grid.Column="6" Style="{DynamicResource TextBlockDefault}" Text="RDM: " />
+                                <controls:Numeric Grid.Row="2" Grid.Column="7" Margin="0,3,0,0" MaxValue="100" MinValue="1" Value="{Binding DancerSettings.RdmPartnerWeight, Mode=TwoWay}" />
+                                
+                                <TextBlock Grid.Row="3" Grid.Column="0" Style="{DynamicResource TextBlockDefault}" Text="BRD: " />
+                                <controls:Numeric Grid.Row="3" Grid.Column="1" Margin="0,3,0,0" MaxValue="100" MinValue="1" Value="{Binding DancerSettings.BrdPartnerWeight, Mode=TwoWay}" />
+                                <TextBlock Grid.Row="3" Grid.Column="3" Style="{DynamicResource TextBlockDefault}" Text="MCH: " />
+                                <controls:Numeric Grid.Row="3" Grid.Column="4" Margin="0,3,0,0" MaxValue="100" MinValue="1" Value="{Binding DancerSettings.MchPartnerWeight, Mode=TwoWay}" />
+                                <TextBlock Grid.Row="3" Grid.Column="6" Style="{DynamicResource TextBlockDefault}" Text="DNC: " />
+                                <controls:Numeric Grid.Row="3" Grid.Column="7" Margin="0,3,0,0" MaxValue="100" MinValue="1" Value="{Binding DancerSettings.DncPartnerWeight, Mode=TwoWay}" />
+                                
+                                <TextBlock Grid.Row="4" Grid.Column="0" Style="{DynamicResource TextBlockDefault}" Text="PLD: " />
+                                <controls:Numeric Grid.Row="4" Grid.Column="1" Margin="0,3,0,0" MaxValue="100" MinValue="1" Value="{Binding DancerSettings.PldPartnerWeight, Mode=TwoWay}" />
+                                <TextBlock Grid.Row="4" Grid.Column="3" Style="{DynamicResource TextBlockDefault}" Text="WAR: " />
+                                <controls:Numeric Grid.Row="4" Grid.Column="4" Margin="0,3,0,0" MaxValue="100" MinValue="1" Value="{Binding DancerSettings.WarPartnerWeight, Mode=TwoWay}" />
+                                <TextBlock Grid.Row="4" Grid.Column="6" Style="{DynamicResource TextBlockDefault}" Text="DRK: " />
+                                <controls:Numeric Grid.Row="4" Grid.Column="7" Margin="0,3,0,0" MaxValue="100" MinValue="1" Value="{Binding DancerSettings.DrkPartnerWeight, Mode=TwoWay}" />
+                                <TextBlock Grid.Row="4" Grid.Column="9" Style="{DynamicResource TextBlockDefault}" Text="GNB: " />
+                                <controls:Numeric Grid.Row="4" Grid.Column="10" Margin="0,3,0,0" MaxValue="100" MinValue="1" Value="{Binding DancerSettings.GnbPartnerWeight, Mode=TwoWay}" />
+                                
+                                <TextBlock Grid.Row="5" Grid.Column="0" Style="{DynamicResource TextBlockDefault}" Text="WHM: " />
+                                <controls:Numeric Grid.Row="5" Grid.Column="1" Margin="0,3,0,0" MaxValue="100" MinValue="1" Value="{Binding DancerSettings.WhmPartnerWeight, Mode=TwoWay}" />
+                                <TextBlock Grid.Row="5" Grid.Column="3" Style="{DynamicResource TextBlockDefault}" Text="SCH: " />
+                                <controls:Numeric Grid.Row="5" Grid.Column="4" Margin="0,3,0,0" MaxValue="100" MinValue="1" Value="{Binding DancerSettings.SchPartnerWeight, Mode=TwoWay}" />
+                                <TextBlock Grid.Row="5" Grid.Column="6" Style="{DynamicResource TextBlockDefault}" Text="AST: " />
+                                <controls:Numeric Grid.Row="5" Grid.Column="7" Margin="0,3,0,0" MaxValue="100" MinValue="1" Value="{Binding DancerSettings.AstPartnerWeight, Mode=TwoWay}" />
+                                <TextBlock Grid.Row="5" Grid.Column="9" Style="{DynamicResource TextBlockDefault}" Text="SAG: " />
+                                <controls:Numeric Grid.Row="5" Grid.Column="10" Margin="0,3,0,0" MaxValue="100" MinValue="1" Value="{Binding DancerSettings.SagPartnerWeight, Mode=TwoWay}" />
+                                
+                            </Grid>
+                        </controls:SettingsBlock>
+                    </Grid>
+                </StackPanel>
+            </StackPanel>
+        </controls:SettingsBlock>
+
+        <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
+            <StackPanel Margin="5">
+                <TextBlock Style="{DynamicResource TextBlockDefault}" Text="Heal :" />
+                <StackPanel Orientation="Horizontal">
+                    <CheckBox Margin="5" Content="Use Improvisation    " IsChecked="{Binding DancerSettings.UseImprovisation, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                </StackPanel>
+                <StackPanel Orientation="Horizontal">
+                    <Grid Margin="5 3 0 3">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="112" />
                             <ColumnDefinition Width="Auto" />
                             <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="30" />
                             <ColumnDefinition Width="Auto" />
                             <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="30" />
                             <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
 
-                        <TextBlock Grid.Row="1" Grid.Column="0" Style="{DynamicResource TextBlockDefault}" Text="MNK: " />
-                        <controls:Numeric Grid.Row="1" Grid.Column="1" Margin="0,3,0,0" MaxValue="100" MinValue="1" Value="{Binding DancerSettings.MnkPartnerWeight, Mode=TwoWay}" />
-                        <TextBlock Grid.Row="1" Grid.Column="3" Style="{DynamicResource TextBlockDefault}" Text="DRG: " />
-                        <controls:Numeric Grid.Row="1" Grid.Column="4" Margin="0,3,0,0" MaxValue="100" MinValue="1" Value="{Binding DancerSettings.DrgPartnerWeight, Mode=TwoWay}" />
-                        <TextBlock Grid.Row="1" Grid.Column="6" Style="{DynamicResource TextBlockDefault}" Text="NIN: " />
-                        <controls:Numeric Grid.Row="1" Grid.Column="7" Margin="0,3,0,0" MaxValue="100" MinValue="1" Value="{Binding DancerSettings.NinPartnerWeight, Mode=TwoWay}" />
-
-                        <TextBlock Grid.Row="2" Grid.Column="0" Style="{DynamicResource TextBlockDefault}" Text="SAM: " />
-                        <controls:Numeric Grid.Row="2" Grid.Column="1" Margin="0,3,0,0" MaxValue="100" MinValue="1" Value="{Binding DancerSettings.SamPartnerWeight, Mode=TwoWay}" />
-                        <TextBlock Grid.Row="2" Grid.Column="3" Style="{DynamicResource TextBlockDefault}" Text="RPR: " />
-                        <controls:Numeric Grid.Row="2" Grid.Column="4" Margin="0,3,0,0" MaxValue="100" MinValue="1" Value="{Binding DancerSettings.RprPartnerWeight, Mode=TwoWay}" />
-                       
-                        <TextBlock Grid.Row="2" Grid.Column="6" Style="{DynamicResource TextBlockDefault}" Text="SMN: " />
-                        <controls:Numeric Grid.Row="2" Grid.Column="7" Margin="0,3,0,0" MaxValue="100" MinValue="1" Value="{Binding DancerSettings.SmnPartnerWeight, Mode=TwoWay}" />
-
-                        <TextBlock Grid.Row="3" Grid.Column="0" Style="{DynamicResource TextBlockDefault}" Text="RDM: " />
-                        <controls:Numeric Grid.Row="3" Grid.Column="1" Margin="0,3,0,0" MaxValue="100" MinValue="1" Value="{Binding DancerSettings.RdmPartnerWeight, Mode=TwoWay}" />
-                        <TextBlock Grid.Row="3" Grid.Column="3" Style="{DynamicResource TextBlockDefault}" Text="BRD: " />
-                        <controls:Numeric Grid.Row="3" Grid.Column="4" Margin="0,3,0,0" MaxValue="100" MinValue="1" Value="{Binding DancerSettings.BrdPartnerWeight, Mode=TwoWay}" />
-                        <TextBlock Grid.Row="3" Grid.Column="6" Style="{DynamicResource TextBlockDefault}" Text="MCH: " />
-                        <controls:Numeric Grid.Row="3" Grid.Column="7" Margin="0,3,0,0" MaxValue="100" MinValue="1" Value="{Binding DancerSettings.MchPartnerWeight, Mode=TwoWay}" />
-
-                        <TextBlock Grid.Row="4" Grid.Column="0" Style="{DynamicResource TextBlockDefault}" Text="DNC: " />
-                        <controls:Numeric Grid.Row="4" Grid.Column="1" Margin="0,3,0,0" MaxValue="100" MinValue="1" Value="{Binding DancerSettings.DncPartnerWeight, Mode=TwoWay}" />
-                        <TextBlock Grid.Row="4" Grid.Column="3" Style="{DynamicResource TextBlockDefault}" Text="PLD: " />
-                        <controls:Numeric Grid.Row="4" Grid.Column="4" Margin="0,3,0,0" MaxValue="100" MinValue="1" Value="{Binding DancerSettings.PldPartnerWeight, Mode=TwoWay}" />
-                        <TextBlock Grid.Row="4" Grid.Column="6" Style="{DynamicResource TextBlockDefault}" Text="WAR: " />
-                        <controls:Numeric Grid.Row="4" Grid.Column="7" Margin="0,3,0,0" MaxValue="100" MinValue="1" Value="{Binding DancerSettings.WarPartnerWeight, Mode=TwoWay}" />
-
-                        <TextBlock Grid.Row="5" Grid.Column="0" Style="{DynamicResource TextBlockDefault}" Text="DRK: " />
-                        <controls:Numeric Grid.Row="5" Grid.Column="1" Margin="0,3,0,0" MaxValue="100" MinValue="1" Value="{Binding DancerSettings.DrkPartnerWeight, Mode=TwoWay}" />
-                        <TextBlock Grid.Row="5" Grid.Column="3" Style="{DynamicResource TextBlockDefault}" Text="GNB: " />
-                        <controls:Numeric Grid.Row="5" Grid.Column="4" Margin="0,3,0,0" MaxValue="100" MinValue="1" Value="{Binding DancerSettings.GnbPartnerWeight, Mode=TwoWay}" />
-                        <TextBlock Grid.Row="5" Grid.Column="6" Style="{DynamicResource TextBlockDefault}" Text="WHM: " />
-                        <controls:Numeric Grid.Row="5" Grid.Column="7" Margin="0,3,0,0" MaxValue="100" MinValue="1" Value="{Binding DancerSettings.WhmPartnerWeight, Mode=TwoWay}" />
-
-                        <TextBlock Grid.Row="6" Grid.Column="0" Style="{DynamicResource TextBlockDefault}" Text="SCH: " />
-                        <controls:Numeric Grid.Row="6" Grid.Column="1" Margin="0,3,0,0" MaxValue="100" MinValue="1" Value="{Binding DancerSettings.SchPartnerWeight, Mode=TwoWay}" />
-                        <TextBlock Grid.Row="6" Grid.Column="3" Style="{DynamicResource TextBlockDefault}" Text="AST: " />
-                        <controls:Numeric Grid.Row="6" Grid.Column="4" Margin="0,3,0,0" MaxValue="100" MinValue="1" Value="{Binding DancerSettings.AstPartnerWeight, Mode=TwoWay}" />
-                        <TextBlock Grid.Row="6" Grid.Column="6" Style="{DynamicResource TextBlockDefault}" Text="SAG: " />
-                        <controls:Numeric Grid.Row="6" Grid.Column="7" Margin="0,3,0,0" MaxValue="100" MinValue="1" Value="{Binding DancerSettings.SagPartnerWeight, Mode=TwoWay}" />
-
-                        <TextBlock Grid.Row="7" Grid.Column="0" Style="{DynamicResource TextBlockDefault}" Text="BLM: " />
-                        <controls:Numeric Grid.Row="7" Grid.Column="1" Margin="0,3,0,0" MaxValue="100" MinValue="1" Value="{Binding DancerSettings.BlmPartnerWeight, Mode=TwoWay}" />
+                        <CheckBox Grid.Column="0" Content="Curing Waltz" IsChecked="{Binding DancerSettings.UseCuringWaltz, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                        <controls:Numeric Grid.Column="1" MaxValue="100" MinValue="1" Value="{Binding DancerSettings.CuringWaltzHP, Mode=TwoWay}" />
+                        <TextBlock Grid.Column="2" Margin="2,0,3,0" Style="{DynamicResource TextBlockDefault}" Text="Health Percent When" />
+                        <controls:Numeric Grid.Column="3" MaxValue="30" MinValue="1" Value="{Binding DancerSettings.CuringWaltzCount, Mode=TwoWay}" />
+                        <TextBlock Grid.Column="4" Margin="2,0,3,0" Style="{DynamicResource TextBlockDefault}" Text=" Allies Need Healing" />
                     </Grid>
-                </controls:SettingsBlock>
-            </Grid>
+                </StackPanel>
+            </StackPanel>
         </controls:SettingsBlock>
 
     </StackPanel>

--- a/Magitek/Views/UserControls/Dancer/General.xaml
+++ b/Magitek/Views/UserControls/Dancer/General.xaml
@@ -3,18 +3,30 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:controls="clr-namespace:Magitek.Controls"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:enums="clr-namespace:Magitek.Enumerations"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:sys="clr-namespace:System;assembly=mscorlib"
              xmlns:viewModels="clr-namespace:Magitek.ViewModels"
              d:DesignHeight="400"
              d:DesignWidth="500"
              mc:Ignorable="d">
 
+    
     <UserControl.DataContext>
         <Binding Source="{x:Static viewModels:BaseSettings.Instance}" />
     </UserControl.DataContext>
 
     <UserControl.Resources>
-        <ResourceDictionary Source="/Magitek;component/Styles/Magitek.xaml" />
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="/Magitek;component/Styles/Magitek.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+            <ObjectDataProvider x:Key="InterruptStrategy" MethodName="GetValues" ObjectType="{x:Type sys:Enum}">
+                <ObjectDataProvider.MethodParameters>
+                    <x:Type TypeName="enums:InterruptStrategy" />
+                </ObjectDataProvider.MethodParameters>
+            </ObjectDataProvider>
+        </ResourceDictionary>
     </UserControl.Resources>
 
     <StackPanel Margin="10">
@@ -25,9 +37,39 @@
             </StackPanel>
         </controls:SettingsBlock>
 
-        <controls:SettingsBlock Background="{DynamicResource ClassSelectorBackground}">
-            <StackPanel Margin="5"/>
+        <controls:SettingsBlock Margin="0 10 0 0" Background="{DynamicResource ClassSelectorBackground}">
+            <StackPanel Margin="5">
+                <CheckBox Content="Use Peloton " IsChecked="{Binding BardSettings.UsePeloton, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+            </StackPanel>
         </controls:SettingsBlock>
+
+        <controls:SettingsBlock Margin="0,2" Background="{DynamicResource ClassSelectorBackground}">
+            <Grid Margin="5 0 0 0">
+                <Grid.RowDefinitions>
+                    <RowDefinition />
+                    <RowDefinition />
+                    <RowDefinition />
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+
+                <CheckBox Grid.Row="0" Grid.Column="0" Content="Second Wind At " IsChecked="{Binding DancerSettings.UseSecondWind, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                <controls:Numeric Grid.Row="0" Grid.Column="1" MaxValue="100" MinValue="1" Value="{Binding DancerSettings.SecondWindHpPercent, Mode=TwoWay}" />
+                <TextBlock Grid.Row="0" Grid.Column="2" Style="{DynamicResource TextBlockDefault}" Text=" Health Percent" />
+
+            </Grid>
+        </controls:SettingsBlock>
+
+        <controls:SettingsBlock Margin="0,10,0,0" Background="{DynamicResource ClassSelectorBackground}">
+            <StackPanel Margin="5 0" Orientation="Horizontal">
+                <CheckBox Content="Use Interrupt and Stun. If activated, use strategy: " IsChecked="{Binding DancerSettings.UseStunOrInterrupt, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                <ComboBox Width="170" ItemsSource="{Binding Source={StaticResource InterruptStrategy}}" SelectedValue="{Binding DancerSettings.Strategy, Mode=TwoWay}" Style="{DynamicResource ComboBox}" />
+            </StackPanel>
+        </controls:SettingsBlock>
+
     </StackPanel>
 </UserControl>
 

--- a/Magitek/Views/UserControls/Dancer/SingleTarget.xaml
+++ b/Magitek/Views/UserControls/Dancer/SingleTarget.xaml
@@ -31,24 +31,36 @@
     <StackPanel Margin="10">
         <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
             <StackPanel Margin="5">
+                <TextBlock Style="{DynamicResource TextBlockDefault}" Text="Dances :" />
                 <StackPanel Orientation="Horizontal">
-                    <CheckBox Content="Use Standard Step" IsChecked="{Binding DancerSettings.UseStandardStep, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <CheckBox Margin="5" Content="Use Standard Step" IsChecked="{Binding DancerSettings.UseStandardStep, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                </StackPanel>
+                <StackPanel Orientation="Horizontal">
+                    <CheckBox Margin="5" Content="Use Technical Step" IsChecked="{Binding DancerSettings.UseTechnicalStep, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                </StackPanel>
+                <StackPanel Orientation="Horizontal">
+                    <CheckBox Margin="5" Content=" Finish Step only when in range" IsChecked="{Binding DancerSettings.OnlyFinishStepInRange, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                 </StackPanel>
             </StackPanel>
         </controls:SettingsBlock>
 
         <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
             <StackPanel Margin="5">
+                <TextBlock Style="{DynamicResource TextBlockDefault}" Text="Spells :" />
                 <StackPanel Orientation="Horizontal">
-                    <CheckBox Content="Use Technical Step" IsChecked="{Binding DancerSettings.UseTechnicalStep, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <CheckBox Margin="5" Content="Use Saber Dance (AOE Spell used in Single Target Rotation)" IsChecked="{Binding DancerSettings.SaberDance, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                 </StackPanel>
-            </StackPanel>
-        </controls:SettingsBlock>
-
-        <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
-            <StackPanel Margin="5">
                 <StackPanel Orientation="Horizontal">
-                    <CheckBox Content="Only Finish Step When In Range" IsChecked="{Binding DancerSettings.OnlyFinishStepInRange, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <CheckBox Margin="5" Content="Use Fan Dance I" IsChecked="{Binding DancerSettings.FanDance1, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                </StackPanel>
+                <StackPanel Orientation="Horizontal">
+                    <CheckBox Margin="5" Content="Use Fan Dance III (AOE Spell used in Single Target Rotation)" IsChecked="{Binding DancerSettings.FanDance3, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                </StackPanel>
+                <StackPanel Orientation="Horizontal">
+                    <CheckBox Margin="5" Content="Use Fan Dance IV (AOE Spell used in Single Target Rotation)" IsChecked="{Binding DancerSettings.FanDance4, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                </StackPanel>
+                <StackPanel Orientation="Horizontal">
+                    <CheckBox Margin="5" Content="Use Starfall Dance (AOE Spell used in Single Target Rotation)" IsChecked="{Binding DancerSettings.StarfallDance, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                 </StackPanel>
             </StackPanel>
         </controls:SettingsBlock>
@@ -61,32 +73,6 @@
             </StackPanel>
         </controls:SettingsBlock>
 
-        <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
-            <Grid Margin="5">
-                <Grid.RowDefinitions>
-                    <RowDefinition />
-                    <RowDefinition />
-                    <RowDefinition />
-                </Grid.RowDefinitions>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto" />
-                    <ColumnDefinition Width="Auto" />
-                    <ColumnDefinition Width="Auto" />
-                </Grid.ColumnDefinitions>
-
-                <CheckBox Grid.Row="0" Grid.Column="0" Content="Second Wind At " IsChecked="{Binding DancerSettings.UseSecondWind, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                <controls:Numeric Grid.Row="0" Grid.Column="1" MaxValue="100" MinValue="1" Value="{Binding DancerSettings.SecondWindHpPercent, Mode=TwoWay}" />
-                <TextBlock Grid.Row="0" Grid.Column="2" Style="{DynamicResource TextBlockDefault}" Text=" Health Percent" />
-
-            </Grid>
-        </controls:SettingsBlock>
-
-        <controls:SettingsBlock Margin="0,5,0,0" Background="{DynamicResource ClassSelectorBackground}">
-            <StackPanel Margin="5" Orientation="Horizontal">
-                <CheckBox Content="Use Interrupt and Stun. If activated, use strategy: " IsChecked="{Binding DancerSettings.UseStunOrInterrupt, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                <ComboBox Width="170" ItemsSource="{Binding Source={StaticResource InterruptStrategy}}" SelectedValue="{Binding DancerSettings.Strategy, Mode=TwoWay}" Style="{DynamicResource ComboBox}" />
-            </StackPanel>
-        </controls:SettingsBlock>
     </StackPanel>
 
 </UserControl>


### PR DESCRIPTION
General: Add Grade 8 potions
DNC: remove SaberDance, Starfall, FanDance 3 & FanDance 4 from UseAoe Toggle as it is part of Single Target rotation
DNC: Rename DanceStep and DanceFinish Gambit properly
DNC: Move Distance Check on Step Finish instead of Basic Step and replace it by Toggle OnlyFinishStepInRange which was not used
DNC: Add Toggle for Fan Dance x and many other spells
DNC: Update Default Toggle config
DNC: Rework UI Config
AST: Update Job with new radius/distance
PLD: Update Job with new radius/distance
RPR: Update Job with new radius/distance
SGE: Update Job with new radius/distance
SAM: Update Job with new radius/distance
WHM: Update Job with new radius/distance