### PR TITLE
DNC Optim + MCH

### DIFF
--- a/Magitek/Controls/GambitsControl.xaml
+++ b/Magitek/Controls/GambitsControl.xaml
@@ -1308,6 +1308,62 @@
                                                                                     </ComboBox>
                                                                                 </DataTemplate>
 
+                                                                                <DataTemplate DataType="{x:Type conditions:DancerEspritCondition}">
+                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Success}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="ESPRIT">
+                                                                                        <StackPanel Width="200">
+                                                                                            <TextBox CaretBrush="White"
+                                                                                                     FontSize="10"
+                                                                                                     Foreground="{DynamicResource Light}"
+                                                                                                     Tag="MINIMUM ESPRIT:"
+                                                                                                     Template="{DynamicResource TextBoxTemplateGambitConditionTextBox}"
+                                                                                                     Text="{Binding EspritMinimum, Mode=TwoWay}" />
+                                                                                            <TextBox CaretBrush="White"
+                                                                                                     FontSize="10"
+                                                                                                     Foreground="{DynamicResource Light}"
+                                                                                                     Tag="MAXIMUM ESPRIT:"
+                                                                                                     Template="{DynamicResource TextBoxTemplateGambitConditionTextBox}"
+                                                                                                     Text="{Binding EspritMaximum, Mode=TwoWay}" />
+
+                                                                                            <Button Margin="0,3,0,0" HorizontalAlignment="Right" Command="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}, Path=DataContext.RemoveGambitCondition}" Content="REMOVE CONDITION" Style="{DynamicResource ButtonGambitAddCondition}">
+                                                                                                <Button.CommandParameter>
+                                                                                                    <MultiBinding Converter="{StaticResource ConditionConverter}">
+                                                                                                        <Binding Path="DataContext" RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type ItemsControl}, AncestorLevel=2}" />
+                                                                                                        <Binding Path="Id" />
+                                                                                                    </MultiBinding>
+                                                                                                </Button.CommandParameter>
+                                                                                            </Button>
+                                                                                        </StackPanel>
+                                                                                    </ComboBox>
+                                                                                </DataTemplate>
+
+                                                                                <DataTemplate DataType="{x:Type conditions:DancerFeatherCondition}">
+                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Success}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="FEATHER">
+                                                                                        <StackPanel Width="200">
+                                                                                            <TextBox CaretBrush="White"
+                                                                                                     FontSize="10"
+                                                                                                     Foreground="{DynamicResource Light}"
+                                                                                                     Tag="MINIMUM FEATHER:"
+                                                                                                     Template="{DynamicResource TextBoxTemplateGambitConditionTextBox}"
+                                                                                                     Text="{Binding FeatherMinimum, Mode=TwoWay}" />
+                                                                                            <TextBox CaretBrush="White"
+                                                                                                     FontSize="10"
+                                                                                                     Foreground="{DynamicResource Light}"
+                                                                                                     Tag="MAXIMUM FEATHER:"
+                                                                                                     Template="{DynamicResource TextBoxTemplateGambitConditionTextBox}"
+                                                                                                     Text="{Binding FeatherMaximum, Mode=TwoWay}" />
+
+                                                                                            <Button Margin="0,3,0,0" HorizontalAlignment="Right" Command="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}, Path=DataContext.RemoveGambitCondition}" Content="REMOVE CONDITION" Style="{DynamicResource ButtonGambitAddCondition}">
+                                                                                                <Button.CommandParameter>
+                                                                                                    <MultiBinding Converter="{StaticResource ConditionConverter}">
+                                                                                                        <Binding Path="DataContext" RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type ItemsControl}, AncestorLevel=2}" />
+                                                                                                        <Binding Path="Id" />
+                                                                                                    </MultiBinding>
+                                                                                                </Button.CommandParameter>
+                                                                                            </Button>
+                                                                                        </StackPanel>
+                                                                                    </ComboBox>
+                                                                                </DataTemplate>
+
                                                                                 <DataTemplate DataType="{x:Type conditions:DragoonGazeCondition}">
                                                                                     <ComboBox Margin="3,0,0,0" Background="{DynamicResource Success}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="GAZE">
                                                                                         <StackPanel Width="200">
@@ -1700,6 +1756,42 @@
                                                                                         </Button>
                                                                                     </StackPanel>
 
+                                                                                    <!--  Dancer  -->
+                                                                                    <StackPanel Margin="5,0">
+                                                                                        <StackPanel.Style>
+                                                                                            <Style TargetType="StackPanel">
+                                                                                                <Setter Property="Visibility" Value="Collapsed" />
+                                                                                                <Style.Triggers>
+                                                                                                    <DataTrigger Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}, Path=DataContext.SelectedJob}" Value="{x:Static enums:ClassJobType.Dancer}">
+                                                                                                        <Setter Property="Visibility" Value="Visible" />
+                                                                                                    </DataTrigger>
+                                                                                                </Style.Triggers>
+                                                                                            </Style>
+                                                                                        </StackPanel.Style>
+                                                                                        <Button Command="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}, Path=DataContext.AddGambitCondition}" Content="ESPRIT" Style="{DynamicResource ButtonGambitAddCondition}">
+                                                                                            <Button.Resources>
+                                                                                                <sys:String x:Key="Condition">DancerEsprit</sys:String>
+                                                                                            </Button.Resources>
+                                                                                            <Button.CommandParameter>
+                                                                                                <MultiBinding Converter="{StaticResource ConditionAddConverter}">
+                                                                                                    <Binding Path="DataContext" RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type ItemsControl}}" />
+                                                                                                    <Binding Source="{StaticResource Condition}" />
+                                                                                                </MultiBinding>
+                                                                                            </Button.CommandParameter>
+                                                                                        </Button>
+                                                                                        <Button Command="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}, Path=DataContext.AddGambitCondition}" Content="FEATHER" Style="{DynamicResource ButtonGambitAddCondition}">
+                                                                                            <Button.Resources>
+                                                                                                <sys:String x:Key="Condition">DancerFeather</sys:String>
+                                                                                            </Button.Resources>
+                                                                                            <Button.CommandParameter>
+                                                                                                <MultiBinding Converter="{StaticResource ConditionAddConverter}">
+                                                                                                    <Binding Path="DataContext" RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type ItemsControl}}" />
+                                                                                                    <Binding Source="{StaticResource Condition}" />
+                                                                                                </MultiBinding>
+                                                                                            </Button.CommandParameter>
+                                                                                        </Button>
+                                                                                    </StackPanel>
+                                                                                    
                                                                                     <!--  Machinist  -->
                                                                                     <StackPanel Margin="5,0">
                                                                                         <StackPanel.Style>
@@ -1712,8 +1804,6 @@
                                                                                                 </Style.Triggers>
                                                                                             </Style>
                                                                                         </StackPanel.Style>
-
-
                                                                                         <Button Command="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}, Path=DataContext.AddGambitCondition}" Content="HEAT" Style="{DynamicResource ButtonGambitAddCondition}">
                                                                                             <Button.Resources>
                                                                                                 <sys:String x:Key="Condition">MachinistHeat</sys:String>
@@ -1725,18 +1815,6 @@
                                                                                                 </MultiBinding>
                                                                                             </Button.CommandParameter>
                                                                                         </Button>
-
-                                                                                        <!--<Button Command="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}, Path=DataContext.AddGambitCondition}" Content="AMMO" Style="{DynamicResource ButtonGambitAddCondition}">
-                                                                                            <Button.Resources>
-                                                                                                <sys:String x:Key="Condition">MachinistAmmo</sys:String>
-                                                                                            </Button.Resources>
-                                                                                            <Button.CommandParameter>
-                                                                                                <MultiBinding Converter="{StaticResource ConditionAddConverter}">
-                                                                                                    <Binding Path="DataContext" RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type ItemsControl}}" />
-                                                                                                    <Binding Source="{StaticResource Condition}" />
-                                                                                                </MultiBinding>
-                                                                                            </Button.CommandParameter>
-                                                                                        </Button>-->
                                                                                     </StackPanel>
 
                                                                                     <!--  Dragoon  -->

--- a/Magitek/Controls/OpenersControl.xaml
+++ b/Magitek/Controls/OpenersControl.xaml
@@ -920,6 +920,62 @@
                                                                         </ComboBox>
                                                                     </DataTemplate>
 
+                                                                    <DataTemplate DataType="{x:Type conditions:DancerEspritCondition}">
+                                                                        <ComboBox Margin="3,0,0,0" Background="{DynamicResource Warning}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="ESPRIT">
+                                                                            <StackPanel Width="200">
+                                                                                <TextBox CaretBrush="White"
+                                                                                         FontSize="10"
+                                                                                         Foreground="{DynamicResource Light}"
+                                                                                         Tag="MINIMUM ESPRIT:"
+                                                                                         Template="{DynamicResource TextBoxTemplateGambitConditionTextBox}"
+                                                                                         Text="{Binding EspritMinimum, Mode=TwoWay}" />
+                                                                                <TextBox CaretBrush="White"
+                                                                                         FontSize="10"
+                                                                                         Foreground="{DynamicResource Light}"
+                                                                                         Tag="MAXIMUM ESPRIT:"
+                                                                                         Template="{DynamicResource TextBoxTemplateGambitConditionTextBox}"
+                                                                                         Text="{Binding EspritMaximum, Mode=TwoWay}" />
+
+                                                                                <Button Margin="0,3,0,0" HorizontalAlignment="Right" Command="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}, Path=DataContext.RemoveStartOpenerCondition}" Content="REMOVE CONDITION" Style="{DynamicResource ButtonGambitAddCondition}">
+                                                                                    <Button.CommandParameter>
+                                                                                        <MultiBinding Converter="{StaticResource OpenerConditionRemoveConverter}">
+                                                                                            <Binding Path="DataContext" RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type ItemsControl}, AncestorLevel=2}" />
+                                                                                            <Binding Path="Id" />
+                                                                                        </MultiBinding>
+                                                                                    </Button.CommandParameter>
+                                                                                </Button>
+                                                                            </StackPanel>
+                                                                        </ComboBox>
+                                                                    </DataTemplate>
+
+                                                                    <DataTemplate DataType="{x:Type conditions:DancerFeatherCondition}">
+                                                                        <ComboBox Margin="3,0,0,0" Background="{DynamicResource Warning}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="FEATHER">
+                                                                            <StackPanel Width="200">
+                                                                                <TextBox CaretBrush="White"
+                                                                                         FontSize="10"
+                                                                                         Foreground="{DynamicResource Light}"
+                                                                                         Tag="MINIMUM FEATHER:"
+                                                                                         Template="{DynamicResource TextBoxTemplateGambitConditionTextBox}"
+                                                                                         Text="{Binding FeatherMinimum, Mode=TwoWay}" />
+                                                                                <TextBox CaretBrush="White"
+                                                                                         FontSize="10"
+                                                                                         Foreground="{DynamicResource Light}"
+                                                                                         Tag="MAXIMUM FEATHER:"
+                                                                                         Template="{DynamicResource TextBoxTemplateGambitConditionTextBox}"
+                                                                                         Text="{Binding FeatherMaximum, Mode=TwoWay}" />
+
+                                                                                <Button Margin="0,3,0,0" HorizontalAlignment="Right" Command="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}, Path=DataContext.RemoveStartOpenerCondition}" Content="REMOVE CONDITION" Style="{DynamicResource ButtonGambitAddCondition}">
+                                                                                    <Button.CommandParameter>
+                                                                                        <MultiBinding Converter="{StaticResource OpenerConditionRemoveConverter}">
+                                                                                            <Binding Path="DataContext" RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type ItemsControl}, AncestorLevel=2}" />
+                                                                                            <Binding Path="Id" />
+                                                                                        </MultiBinding>
+                                                                                    </Button.CommandParameter>
+                                                                                </Button>
+                                                                            </StackPanel>
+                                                                        </ComboBox>
+                                                                    </DataTemplate>
+
                                                                     <DataTemplate DataType="{x:Type conditions:DragoonGazeCondition}">
                                                                         <ComboBox Margin="3,0,0,0" Background="{DynamicResource Warning}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="GAZE">
                                                                             <StackPanel Width="200">
@@ -1397,6 +1453,43 @@
                                                                             </Button>
                                                                         </StackPanel>
 
+                                                                        <!--  Dancer  -->
+                                                                        <StackPanel Margin="5,0">
+                                                                            <StackPanel.Style>
+                                                                                <Style TargetType="StackPanel">
+                                                                                    <Setter Property="Visibility" Value="Collapsed" />
+                                                                                    <Style.Triggers>
+                                                                                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}, Path=DataContext.SelectedJob}" Value="{x:Static enums:ClassJobType.Dancer}">
+                                                                                            <Setter Property="Visibility" Value="Visible" />
+                                                                                        </DataTrigger>
+                                                                                    </Style.Triggers>
+                                                                                </Style>
+                                                                            </StackPanel.Style>
+                                                                            <Button Command="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}, Path=DataContext.AddOpenerCondition}" Content="ESPRIT" Style="{DynamicResource ButtonGambitAddCondition}">
+                                                                                <Button.Resources>
+                                                                                    <sys:String x:Key="Condition">DancerEsprit</sys:String>
+                                                                                </Button.Resources>
+                                                                                <Button.CommandParameter>
+                                                                                    <MultiBinding Converter="{StaticResource OpenerConditionAddConverter}">
+                                                                                        <Binding Path="DataContext" RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type ItemsControl}}" />
+                                                                                        <Binding Source="{StaticResource Condition}" />
+                                                                                    </MultiBinding>
+                                                                                </Button.CommandParameter>
+                                                                            </Button>
+                                                                            <Button Command="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}, Path=DataContext.AddOpenerCondition}" Content="FEATHER" Style="{DynamicResource ButtonGambitAddCondition}">
+                                                                                <Button.Resources>
+                                                                                    <sys:String x:Key="Condition">DancerFeather</sys:String>
+                                                                                </Button.Resources>
+                                                                                <Button.CommandParameter>
+                                                                                    <MultiBinding Converter="{StaticResource OpenerConditionAddConverter}">
+                                                                                        <Binding Path="DataContext" RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type ItemsControl}}" />
+                                                                                        <Binding Source="{StaticResource Condition}" />
+                                                                                    </MultiBinding>
+                                                                                </Button.CommandParameter>
+                                                                            </Button>
+                                                                        </StackPanel>
+                                                                        
+                                                                        
                                                                         <!--  Machinist  -->
                                                                         <StackPanel Margin="5,0">
                                                                             <StackPanel.Style>
@@ -2488,6 +2581,62 @@
                                                                                     </ComboBox>
                                                                                 </DataTemplate>
 
+                                                                                <DataTemplate DataType="{x:Type conditions:DancerEspritCondition}">
+                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Success}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="ESPRIT">
+                                                                                        <StackPanel Width="200">
+                                                                                            <TextBox CaretBrush="White"
+                                                                                                     FontSize="10"
+                                                                                                     Foreground="{DynamicResource Light}"
+                                                                                                     Tag="MINIMUM ESPRIT:"
+                                                                                                     Template="{DynamicResource TextBoxTemplateGambitConditionTextBox}"
+                                                                                                     Text="{Binding EspritMinimum, Mode=TwoWay}" />
+                                                                                            <TextBox CaretBrush="White"
+                                                                                                     FontSize="10"
+                                                                                                     Foreground="{DynamicResource Light}"
+                                                                                                     Tag="MAXIMUM ESPRIT:"
+                                                                                                     Template="{DynamicResource TextBoxTemplateGambitConditionTextBox}"
+                                                                                                     Text="{Binding EspritMaximum, Mode=TwoWay}" />
+
+                                                                                            <Button Margin="0,3,0,0" HorizontalAlignment="Right" Command="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}, Path=DataContext.RemoveGambitCondition}" Content="REMOVE CONDITION" Style="{DynamicResource ButtonGambitAddCondition}">
+                                                                                                <Button.CommandParameter>
+                                                                                                    <MultiBinding Converter="{StaticResource ConditionConverter}">
+                                                                                                        <Binding Path="DataContext" RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type ItemsControl}, AncestorLevel=2}" />
+                                                                                                        <Binding Path="Id" />
+                                                                                                    </MultiBinding>
+                                                                                                </Button.CommandParameter>
+                                                                                            </Button>
+                                                                                        </StackPanel>
+                                                                                    </ComboBox>
+                                                                                </DataTemplate>
+
+                                                                                <DataTemplate DataType="{x:Type conditions:DancerFeatherCondition}">
+                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Success}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="FEATHER">
+                                                                                        <StackPanel Width="200">
+                                                                                            <TextBox CaretBrush="White"
+                                                                                                     FontSize="10"
+                                                                                                     Foreground="{DynamicResource Light}"
+                                                                                                     Tag="MINIMUM FEATHER:"
+                                                                                                     Template="{DynamicResource TextBoxTemplateGambitConditionTextBox}"
+                                                                                                     Text="{Binding FeatherMinimum, Mode=TwoWay}" />
+                                                                                            <TextBox CaretBrush="White"
+                                                                                                     FontSize="10"
+                                                                                                     Foreground="{DynamicResource Light}"
+                                                                                                     Tag="MAXIMUM FEATHER:"
+                                                                                                     Template="{DynamicResource TextBoxTemplateGambitConditionTextBox}"
+                                                                                                     Text="{Binding FeatherMaximum, Mode=TwoWay}" />
+
+                                                                                            <Button Margin="0,3,0,0" HorizontalAlignment="Right" Command="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}, Path=DataContext.RemoveGambitCondition}" Content="REMOVE CONDITION" Style="{DynamicResource ButtonGambitAddCondition}">
+                                                                                                <Button.CommandParameter>
+                                                                                                    <MultiBinding Converter="{StaticResource ConditionConverter}">
+                                                                                                        <Binding Path="DataContext" RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type ItemsControl}, AncestorLevel=2}" />
+                                                                                                        <Binding Path="Id" />
+                                                                                                    </MultiBinding>
+                                                                                                </Button.CommandParameter>
+                                                                                            </Button>
+                                                                                        </StackPanel>
+                                                                                    </ComboBox>
+                                                                                </DataTemplate>
+
                                                                                 <DataTemplate DataType="{x:Type conditions:DragoonGazeCondition}">
                                                                                     <ComboBox Margin="3,0,0,0" Background="{DynamicResource Success}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="GAZE">
                                                                                         <StackPanel Width="200">
@@ -2964,6 +3113,42 @@
                                                                                         <Button Command="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}, Path=DataContext.AddGambitCondition}" Content="REPERTOIRE" Style="{DynamicResource ButtonGambitAddCondition}">
                                                                                             <Button.Resources>
                                                                                                 <sys:String x:Key="Condition">BardRepertoire</sys:String>
+                                                                                            </Button.Resources>
+                                                                                            <Button.CommandParameter>
+                                                                                                <MultiBinding Converter="{StaticResource ConditionAddConverter}">
+                                                                                                    <Binding Path="DataContext" RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type ItemsControl}}" />
+                                                                                                    <Binding Source="{StaticResource Condition}" />
+                                                                                                </MultiBinding>
+                                                                                            </Button.CommandParameter>
+                                                                                        </Button>
+                                                                                    </StackPanel>
+
+                                                                                    <!--  Dancer  -->
+                                                                                    <StackPanel Margin="5,0">
+                                                                                        <StackPanel.Style>
+                                                                                            <Style TargetType="StackPanel">
+                                                                                                <Setter Property="Visibility" Value="Collapsed" />
+                                                                                                <Style.Triggers>
+                                                                                                    <DataTrigger Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}, Path=DataContext.SelectedJob}" Value="{x:Static enums:ClassJobType.Dancer}">
+                                                                                                        <Setter Property="Visibility" Value="Visible" />
+                                                                                                    </DataTrigger>
+                                                                                                </Style.Triggers>
+                                                                                            </Style>
+                                                                                        </StackPanel.Style>
+                                                                                        <Button Command="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}, Path=DataContext.AddGambitCondition}" Content="ESPRIT" Style="{DynamicResource ButtonGambitAddCondition}">
+                                                                                            <Button.Resources>
+                                                                                                <sys:String x:Key="Condition">DancerEsprit</sys:String>
+                                                                                            </Button.Resources>
+                                                                                            <Button.CommandParameter>
+                                                                                                <MultiBinding Converter="{StaticResource ConditionAddConverter}">
+                                                                                                    <Binding Path="DataContext" RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type ItemsControl}}" />
+                                                                                                    <Binding Source="{StaticResource Condition}" />
+                                                                                                </MultiBinding>
+                                                                                            </Button.CommandParameter>
+                                                                                        </Button>
+                                                                                        <Button Command="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}, Path=DataContext.AddGambitCondition}" Content="FEATHER" Style="{DynamicResource ButtonGambitAddCondition}">
+                                                                                            <Button.Resources>
+                                                                                                <sys:String x:Key="Condition">DancerFeather</sys:String>
                                                                                             </Button.Resources>
                                                                                             <Button.CommandParameter>
                                                                                                 <MultiBinding Converter="{StaticResource ConditionAddConverter}">

--- a/Magitek/Converters/GambitConditionConverter.cs
+++ b/Magitek/Converters/GambitConditionConverter.cs
@@ -86,6 +86,12 @@ namespace Magitek.Converters
                     case GambitConditionTypes.MachinistHeat:
                         condition = new MachinistHeatCondition();
                         break;
+                    case GambitConditionTypes.DancerEsprit:
+                        condition = new DancerEspritCondition();
+                        break;
+                    case GambitConditionTypes.DancerFeather:
+                        condition = new DancerFeatherCondition();
+                        break;
                     case GambitConditionTypes.DragoonGaze:
                         condition = new DragoonGazeCondition();
                         break;

--- a/Magitek/Gambits/Conditions/DancerEspritCondition.cs
+++ b/Magitek/Gambits/Conditions/DancerEspritCondition.cs
@@ -1,0 +1,26 @@
+﻿using ff14bot.Managers;
+using ff14bot.Objects;
+
+namespace Magitek.Gambits.Conditions
+{
+    public class DancerEspritCondition : GambitCondition
+    {
+        public DancerEspritCondition() : base(GambitConditionTypes.DancerEsprit)
+        {
+        }
+
+        public int EspritMinimum { get; set; }
+        public int EspritMaximum { get; set; }
+
+        public override bool Check(GameObject gameObject = null)
+        {
+            if (ActionResourceManager.Dancer.Esprit < EspritMinimum)
+                return false;
+
+            if (ActionResourceManager.Dancer.Esprit > EspritMaximum)
+                return false;
+
+            return true;
+        }
+    }
+}

--- a/Magitek/Gambits/Conditions/DancerFeatherCondition.cs
+++ b/Magitek/Gambits/Conditions/DancerFeatherCondition.cs
@@ -1,0 +1,26 @@
+﻿using ff14bot.Managers;
+using ff14bot.Objects;
+
+namespace Magitek.Gambits.Conditions
+{
+    public class DancerFeatherCondition : GambitCondition
+    {
+        public DancerFeatherCondition() : base(GambitConditionTypes.DancerFeather)
+        {
+        }
+
+        public int FeatherMinimum { get; set; }
+        public int FeatherMaximum { get; set; }
+
+        public override bool Check(GameObject gameObject = null)
+        {
+            if (ActionResourceManager.Dancer.FourFoldFeathers < FeatherMinimum)
+                return false;
+
+            if (ActionResourceManager.Dancer.FourFoldFeathers > FeatherMaximum)
+                return false;
+
+            return true;
+        }
+    }
+}

--- a/Magitek/Gambits/Conditions/GambitCondition.cs
+++ b/Magitek/Gambits/Conditions/GambitCondition.cs
@@ -42,6 +42,8 @@ namespace Magitek.Gambits.Conditions
         SpellOffCooldown,
         BardRepertoire,
         MachinistHeat,
+        DancerFeather,
+        DancerEsprit,
         DragoonGaze,
         DragoonGaugeTimer,
         NinjaHuton,

--- a/Magitek/Gambits/Helpers/ConditionHelpers.cs
+++ b/Magitek/Gambits/Helpers/ConditionHelpers.cs
@@ -111,6 +111,14 @@ namespace Magitek.Gambits.Helpers
                     condition = new MachinistHeatCondition();
                     break;
 
+                case "DancerEsprit":
+                    condition = new DancerEspritCondition();
+                    break;
+
+                case "DancerFeather":
+                    condition = new DancerFeatherCondition();
+                    break;
+
                 case "DragoonGaze":
                     condition = new DragoonGazeCondition();
                     break;

--- a/Magitek/Logic/Dancer/Aoe.cs
+++ b/Magitek/Logic/Dancer/Aoe.cs
@@ -66,11 +66,14 @@ namespace Magitek.Logic.Dancer
             if (!DancerSettings.Instance.FanDance3)
                 return false;
 
-            if (Core.Me.ClassLevel < Spells.FanDance3.LevelAcquired) return false;
+            if (Core.Me.ClassLevel < Spells.FanDance3.LevelAcquired)
+                return false;
 
-            if (Core.Me.HasAura(Auras.StandardStep) || Core.Me.HasAura(Auras.TechnicalStep)) return false;
+            if (Core.Me.HasAura(Auras.StandardStep) || Core.Me.HasAura(Auras.TechnicalStep))
+                return false;
 
-            if (!Core.Me.HasAura(Auras.ThreefoldFanDance)) return false;
+            if (!Core.Me.HasAura(Auras.ThreefoldFanDance))
+                return false;
 
             return await Spells.FanDance3.Cast(Core.Me.CurrentTarget);
         }
@@ -83,20 +86,20 @@ namespace Magitek.Logic.Dancer
             if (Core.Me.ClassLevel < Spells.SaberDance.LevelAcquired)
                 return false;
 
-            if (Core.Me.HasAura(Auras.StandardStep) || Core.Me.HasAura(Auras.TechnicalStep)) 
+            if (Core.Me.HasAura(Auras.StandardStep) || Core.Me.HasAura(Auras.TechnicalStep))
                 return false;
 
             if (DancerSettings.Instance.UseRangeAndFacingChecks)
-                if (Core.Me.CurrentTarget.Distance(Core.Me) > Spells.SaberDance.Range) 
+                if (Core.Me.CurrentTarget.Distance(Core.Me) - Core.Me.CurrentTarget.CombatReach > Spells.SaberDance.Range)
                     return false;
 
             if (ActionResourceManager.Dancer.Esprit < 50)
-                return false; 
-            
+                return false;
+
             if (ActionResourceManager.Dancer.Esprit >= 100)
                 return await Spells.SaberDance.Cast(Core.Me.CurrentTarget);
 
-            if (!Core.Me.HasAura(Auras.TechnicalFinish)) 
+            if (!Core.Me.HasAura(Auras.TechnicalFinish))
             {
                 if (ActionResourceManager.Dancer.Esprit >= DancerSettings.Instance.SaberDanceEsprit)
                 {
@@ -141,19 +144,19 @@ namespace Magitek.Logic.Dancer
 
         public static async Task<bool> Bloodshower()
         {
-            if (!DancerSettings.Instance.UseAoe) 
+            if (!DancerSettings.Instance.UseAoe)
                 return false;
 
-            if (!DancerSettings.Instance.Bloodshower) 
+            if (!DancerSettings.Instance.Bloodshower)
                 return false;
 
-            if (Core.Me.HasAura(Auras.StandardStep) || Core.Me.HasAura(Auras.TechnicalStep)) 
+            if (Core.Me.HasAura(Auras.StandardStep) || Core.Me.HasAura(Auras.TechnicalStep))
                 return false;
 
-            if (Combat.Enemies.Count(r => r.Distance(Core.Me) <= Spells.Bloodshower.Radius + r.CombatReach) < DancerSettings.Instance.BloodshowerEnemies) 
+            if (Combat.Enemies.Count(r => r.Distance(Core.Me) <= Spells.Bloodshower.Radius + r.CombatReach) < DancerSettings.Instance.BloodshowerEnemies)
                 return false;
 
-            if (!Core.Me.HasAura(Auras.SilkenFlow) && !Core.Me.HasAura(Auras.FlourishingFlow)) 
+            if (!Core.Me.HasAura(Auras.SilkenFlow) && !Core.Me.HasAura(Auras.FlourishingFlow))
                 return false;
 
             return await Spells.Bloodshower.Cast(Core.Me);

--- a/Magitek/Logic/Dancer/Aoe.cs
+++ b/Magitek/Logic/Dancer/Aoe.cs
@@ -1,9 +1,11 @@
 using ff14bot;
+using ff14bot.Objects;
 using ff14bot.Managers;
 using Magitek.Extensions;
 using Magitek.Logic.Roles;
 using Magitek.Models.Dancer;
 using Magitek.Utilities;
+using Auras = Magitek.Utilities.Auras;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -21,15 +23,20 @@ namespace Magitek.Logic.Dancer
             if (!DancerSettings.Instance.StarfallDance)
                 return false;
 
-            if (Core.Me.ClassLevel < Spells.StarfallDance.LevelAcquired) return false;
+            if (Core.Me.ClassLevel < Spells.StarfallDance.LevelAcquired) 
+                return false;
 
-            if (!Core.Me.HasAura(Auras.FlourishingStarfall)) return false;
+            if (!Core.Me.HasAura(Auras.FlourishingStarfall)) 
+                return false;
 
-            if (Core.Me.HasAura(Auras.StandardStep) || Core.Me.HasAura(Auras.TechnicalStep)) return false;
+            if (Core.Me.HasAura(Auras.StandardStep) || Core.Me.HasAura(Auras.TechnicalStep)) 
+                return false;
 
-            if (!Core.Me.CurrentTarget.InCustomDegreeCone(15)) return false;
-
-            //if (Core.Me.CurrentTarget.Distance(Core.Me) > Spells.StarfallDance.Range) return false;
+            if (ActionResourceManager.Dancer.Esprit >= 100)
+                return false; 
+            
+            if (!Core.Me.CurrentTarget.InCustomDegreeCone(15)) 
+                return false;
 
             return await Spells.StarfallDance.Cast(Core.Me.CurrentTarget);
         }
@@ -39,15 +46,17 @@ namespace Magitek.Logic.Dancer
             if (!DancerSettings.Instance.FanDance4)
                 return false;
 
-            if (Core.Me.ClassLevel < Spells.FanDanceIV.LevelAcquired) return false;
+            if (Core.Me.ClassLevel < Spells.FanDanceIV.LevelAcquired) 
+                return false;
 
-            if (Core.Me.HasAura(Auras.StandardStep) || Core.Me.HasAura(Auras.TechnicalStep)) return false;
+            if (Core.Me.HasAura(Auras.StandardStep) || Core.Me.HasAura(Auras.TechnicalStep)) 
+                return false;
 
-            if (!Core.Me.HasAura(Auras.FourfoldFanDance)) return false;
+            if (!Core.Me.HasAura(Auras.FourfoldFanDance)) 
+                return false;
 
-            if (!Core.Me.CurrentTarget.InCustomRadiantCone(Spells.StarfallDance.Radius)) return false;
-
-            //if (Core.Me.CurrentTarget.Distance(Core.Me) > Spells.FanDanceIV.Range) return false;
+            if (!Core.Me.CurrentTarget.InCustomRadiantCone(Spells.StarfallDance.Radius)) 
+                return false;
 
             return await Spells.FanDanceIV.Cast(Core.Me.CurrentTarget);
         }
@@ -74,23 +83,46 @@ namespace Magitek.Logic.Dancer
             if (Core.Me.ClassLevel < Spells.SaberDance.LevelAcquired)
                 return false;
 
-            if (Core.Me.HasAura(Auras.StandardStep) || Core.Me.HasAura(Auras.TechnicalStep)) return false;
-
-            if (DancerSettings.Instance.UseRangeAndFacingChecks)
-                if (Core.Me.CurrentTarget.Distance(Core.Me) > Spells.SaberDance.Range) return false;
-
-            if (ActionResourceManager.Dancer.Esprit >= 85)
-                return await Spells.SaberDance.Cast(Core.Me.CurrentTarget);
-
-            if (!Core.Me.HasAura(Auras.TechnicalFinish))
+            if (Core.Me.HasAura(Auras.StandardStep) || Core.Me.HasAura(Auras.TechnicalStep)) 
                 return false;
 
+            if (DancerSettings.Instance.UseRangeAndFacingChecks)
+                if (Core.Me.CurrentTarget.Distance(Core.Me) > Spells.SaberDance.Range) 
+                    return false;
+
+            if (ActionResourceManager.Dancer.Esprit < 50)
+                return false; 
+            
+            if (ActionResourceManager.Dancer.Esprit >= 100)
+                return await Spells.SaberDance.Cast(Core.Me.CurrentTarget);
+
+            if (!Core.Me.HasAura(Auras.TechnicalFinish)) 
+            {
+                if (ActionResourceManager.Dancer.Esprit >= DancerSettings.Instance.SaberDanceEsprit)
+                {
+                    //Fountainfall - Bloodshower
+                    Aura SilkenFlowAura = (Core.Me as Character).Auras.FirstOrDefault(x => x.Id == Auras.SilkenFlow);
+                    if (Core.Me.HasAura(Auras.SilkenFlow) && SilkenFlowAura.TimespanLeft.TotalMilliseconds < 3000)
+                        return false;
+
+                    //Reverse Cascade - RisingWindmill
+                    Aura SilkenSymmetryAura = (Core.Me as Character).Auras.FirstOrDefault(x => x.Id == Auras.SilkenSymmetry);
+                    if (Core.Me.HasAura(Auras.SilkenSymmetry) && SilkenSymmetryAura.TimespanLeft.TotalMilliseconds < 3000)
+                        return false;
+
+                    return await Spells.SaberDance.Cast(Core.Me.CurrentTarget);
+                }
+
+                return false;
+                //if (ActionResourceManager.Dancer.Esprit >= 70 && Spells.StandardStep.IsKnownAndReady(5000))
+                //    return await Spells.SaberDance.Cast(Core.Me.CurrentTarget);
+            }
             return await Spells.SaberDance.Cast(Core.Me.CurrentTarget);
         }
 
 
         /*************************************************************************************
-         *                                       AOE
+         *                          AOE used in Multiple Target Rotation
          * ***********************************************************************************/
         public static async Task<bool> FanDance2()
         {
@@ -100,7 +132,7 @@ namespace Magitek.Logic.Dancer
 
             if (Core.Me.HasAura(Auras.StandardStep) || Core.Me.HasAura(Auras.TechnicalStep)) return false;
 
-            if (Combat.Enemies.Count(r => r.Distance(Core.Me) <= 5 + r.CombatReach) < DancerSettings.Instance.FanDanceTwoEnemies) return false;
+            if (Combat.Enemies.Count(r => r.Distance(Core.Me) <= Spells.FanDance2.Radius + r.CombatReach) < DancerSettings.Instance.FanDanceTwoEnemies) return false;
 
             if (ActionResourceManager.Dancer.FourFoldFeathers < 4 && !Core.Me.HasAura(Auras.Devilment) && Core.Me.ClassLevel >= 62) return false;
 
@@ -109,60 +141,80 @@ namespace Magitek.Logic.Dancer
 
         public static async Task<bool> Bloodshower()
         {
-            if (!DancerSettings.Instance.UseAoe) return false;
+            if (!DancerSettings.Instance.UseAoe) 
+                return false;
 
-            if (!DancerSettings.Instance.Bloodshower) return false;
+            if (!DancerSettings.Instance.Bloodshower) 
+                return false;
 
-            if (Core.Me.HasAura(Auras.StandardStep) || Core.Me.HasAura(Auras.TechnicalStep)) return false;
+            if (Core.Me.HasAura(Auras.StandardStep) || Core.Me.HasAura(Auras.TechnicalStep)) 
+                return false;
 
-            if (Combat.Enemies.Count(r => r.Distance(Core.Me) <= 5 + r.CombatReach) < DancerSettings.Instance.BloodshowerEnemies) return false;
+            if (Combat.Enemies.Count(r => r.Distance(Core.Me) <= Spells.Bloodshower.Radius + r.CombatReach) < DancerSettings.Instance.BloodshowerEnemies) 
+                return false;
 
-            if (!Core.Me.HasAura(Auras.SilkenFlow) && !Core.Me.HasAura(Auras.FlourishingFlow)) return false;
+            if (!Core.Me.HasAura(Auras.SilkenFlow) && !Core.Me.HasAura(Auras.FlourishingFlow)) 
+                return false;
 
             return await Spells.Bloodshower.Cast(Core.Me);
         }
 
         public static async Task<bool> RisingWindmill()
         {
-            if (!DancerSettings.Instance.UseAoe) return false;
+            if (!DancerSettings.Instance.UseAoe) 
+                return false;
 
-            if (!DancerSettings.Instance.RisingWindmill) return false;
+            if (!DancerSettings.Instance.RisingWindmill) 
+                return false;
 
-            if (Core.Me.HasAura(Auras.StandardStep) || Core.Me.HasAura(Auras.TechnicalStep)) return false;
+            if (Core.Me.HasAura(Auras.StandardStep) || Core.Me.HasAura(Auras.TechnicalStep)) 
+                return false;
 
-            if (Combat.Enemies.Count(r => r.Distance(Core.Me) <= 5 + r.CombatReach) < DancerSettings.Instance.RisingWindmillEnemies) return false;
+            if (Combat.Enemies.Count(r => r.Distance(Core.Me) <= Spells.RisingWindmill.Radius + r.CombatReach) < DancerSettings.Instance.RisingWindmillEnemies) 
+                return false;
 
-            if (Core.Me.CurrentTarget == null) return false;
+            if (Core.Me.CurrentTarget == null) 
+                return false;
 
-            if (!Core.Me.HasAura(Auras.FlourishingSymmetry) && !Core.Me.HasAura(Auras.SilkenSymmetry)) return false;
+            if (!Core.Me.HasAura(Auras.FlourishingSymmetry) && !Core.Me.HasAura(Auras.SilkenSymmetry)) 
+                return false;
 
             return await Spells.RisingWindmill.Cast(Core.Me);
         }
 
         public static async Task<bool> Bladeshower()
         {
-            if (!DancerSettings.Instance.UseAoe) return false;
+            if (!DancerSettings.Instance.UseAoe) 
+                return false;
 
-            if (!DancerSettings.Instance.Bladeshower) return false;
+            if (!DancerSettings.Instance.Bladeshower) 
+                return false;
 
-            if (Core.Me.HasAura(Auras.StandardStep) || Core.Me.HasAura(Auras.TechnicalStep)) return false;
+            if (Core.Me.HasAura(Auras.StandardStep) || Core.Me.HasAura(Auras.TechnicalStep)) 
+                return false;
 
-            if (Combat.Enemies.Count(r => r.Distance(Core.Me) <= 5 + r.CombatReach) < DancerSettings.Instance.BladeshowerEnemies) return false;
+            if (Combat.Enemies.Count(r => r.Distance(Core.Me) <= Spells.Bladeshower.Radius + r.CombatReach) < DancerSettings.Instance.BladeshowerEnemies) 
+                return false;
 
-            if (ActionManager.LastSpell != Spells.Windmill) return false;
+            if (ActionManager.LastSpell != Spells.Windmill) 
+                return false;
 
             return await Spells.Bladeshower.Cast(Core.Me);
         }
 
         public static async Task<bool> Windmill()
         {
-            if (!DancerSettings.Instance.UseAoe) return false;
+            if (!DancerSettings.Instance.UseAoe) 
+                return false;
 
-            if (!DancerSettings.Instance.Windmill) return false;
+            if (!DancerSettings.Instance.Windmill) 
+                return false;
 
-            if (Core.Me.HasAura(Auras.StandardStep) || Core.Me.HasAura(Auras.TechnicalStep)) return false;
+            if (Core.Me.HasAura(Auras.StandardStep) || Core.Me.HasAura(Auras.TechnicalStep)) 
+                return false;
 
-            if (Combat.Enemies.Count(r => r.Distance(Core.Me) <= 5 + r.CombatReach) < DancerSettings.Instance.WindmillEnemies) return false;
+            if (Combat.Enemies.Count(r => r.Distance(Core.Me) <= Spells.Windmill.Radius + r.CombatReach) < DancerSettings.Instance.WindmillEnemies) 
+                return false;
 
             return await Spells.Windmill.Cast(Core.Me);
         }

--- a/Magitek/Logic/Dancer/Buff.cs
+++ b/Magitek/Logic/Dancer/Buff.cs
@@ -17,12 +17,47 @@ namespace Magitek.Logic.Dancer
 {
     internal static class Buff
     {
+
+        /************************************************************************************************************************
+         *                                                 Damage
+         * **********************************************************************************************************************/
         public static async Task<bool> Devilment()
         {
             if (!DancerSettings.Instance.UseDevilment)
                 return false;
 
+            if (Core.Me.HasAura(Auras.StandardStep) || Core.Me.HasAura(Auras.TechnicalStep))
+                return false;
+
             if (DancerSettings.Instance.DevilmentWithTechnicalStep)
+            {
+                if (ActionManager.HasSpell(Spells.TechnicalStep.Id) && Spells.TechnicalStep.Cooldown > TimeSpan.FromMilliseconds(1000))
+                    return false;
+
+                if (!Core.Me.HasAura(Auras.StandardFinish))
+                    return false;
+            }
+            else
+            {
+                if (Spells.StandardStep.IsKnownAndReady())
+                    return false;
+
+                if (Spells.TechnicalStep.IsKnownAndReady())
+                    return false;
+            }
+
+            return await Spells.Devilment.Cast(Core.Me);
+        }
+
+        public static async Task<bool> Flourish()
+        {
+            if (!DancerSettings.Instance.UseFlourish)
+                return false;
+
+            if (!Core.Me.HasAura(Auras.StandardFinish))
+                return false;
+
+            if (Core.Me.HasAnyAura(FlourishingAuras))
                 return false;
 
             if (Spells.StandardStep.IsKnownAndReady())
@@ -31,32 +66,21 @@ namespace Magitek.Logic.Dancer
             if (Spells.TechnicalStep.IsKnownAndReady())
                 return false;
 
-            if (Core.Me.HasAura(Auras.StandardStep) || Core.Me.HasAura(Auras.TechnicalStep))
-                return false;
-
-            return await Spells.Devilment.Cast(Core.Me);
-        }
-
-        public static async Task<bool> PreTechnicalDevilment()
-        {
-            if (!DancerSettings.Instance.UseDevilment)
-                return false;
-
             if (DancerSettings.Instance.DevilmentWithFlourish)
-                return false;
+            {
+                if (Spells.Devilment.IsKnownAndReady())
+                    return false;
+            }
 
             if (Core.Me.HasAura(Auras.StandardStep) || Core.Me.HasAura(Auras.TechnicalStep))
                 return false;
 
-            if (DancerSettings.Instance.DevilmentWithTechnicalStep && ActionManager.HasSpell(Spells.TechnicalStep.Id) && Spells.TechnicalStep.Cooldown > TimeSpan.FromMilliseconds(1000))
-                return false;
-
-            if (DancerSettings.Instance.DevilmentWithTechnicalStep && !Core.Me.HasAura(Auras.StandardFinish))
-                return false;
-
-            return await Spells.Devilment.Cast(Core.Me);
+            return await Spells.Flourish.Cast(Core.Me);
         }
 
+        /************************************************************************************************************************
+         *                                                 Healing
+         * **********************************************************************************************************************/
         public static async Task<bool> CuringWaltz()
         {
             if (!DancerSettings.Instance.UseCuringWaltz)
@@ -97,35 +121,10 @@ namespace Magitek.Logic.Dancer
 
         private static uint[] FlourishingAuras = { Auras.FlourishingSymmetry, Auras.FlourishingFlow, Auras.ThreefoldFanDance, Auras.FourfoldFanDance };
 
-        public static async Task<bool> Flourish()
-        {
-            if (!DancerSettings.Instance.UseFlourish)
-                return false;
 
-            if (!Core.Me.HasAura(Auras.StandardFinish))
-                return false;
-
-            if (Core.Me.HasAnyAura(FlourishingAuras))
-                return false;
-
-            if (Spells.StandardStep.IsKnownAndReady())
-                return false;
-
-            if (Spells.TechnicalStep.IsKnownAndReady())
-                return false;
-
-            if (DancerSettings.Instance.DevilmentWithFlourish)
-            {
-                if (Spells.Devilment.IsKnownAndReady())
-                    return false;
-            }
-
-            if (Core.Me.HasAura(Auras.StandardStep) || Core.Me.HasAura(Auras.TechnicalStep))
-                return false;
-
-            return await Spells.Flourish.Cast(Core.Me);
-        }
-
+        /************************************************************************************************************************
+         *                                                 Dance Partner
+         * **********************************************************************************************************************/
         public static async Task<bool> DancePartner()
         {
             if (!DancerSettings.Instance.UseClosedPosition)
@@ -251,9 +250,12 @@ namespace Magitek.Logic.Dancer
             return c.CurrentJob == ClassJobType.Adventurer ? 70 : 0;
         }
 
+        /************************************************************************************************************************
+         *                                                 Potion
+         * **********************************************************************************************************************/
         public static async Task<bool> UsePotion()
         {
-            if (Spells.Devilment.IsKnown() && !Spells.Devilment.IsReady(11000))
+            if (Spells.Devilment.IsKnown() && !Spells.Devilment.IsReady(8000))
                 return false;
 
             return await PhysicalDps.UsePotion(DancerSettings.Instance);

--- a/Magitek/Magitek.csproj
+++ b/Magitek/Magitek.csproj
@@ -207,6 +207,7 @@
     <Compile Include="Gambits\Actions\UseItemOnSelfAction.cs" />
     <Compile Include="Gambits\Conditions\BardRepertoireCondition.cs" />
     <Compile Include="Gambits\Conditions\CombatTimeCondition.cs" />
+    <Compile Include="Gambits\Conditions\DancerFeatherCondition.cs" />
     <Compile Include="Gambits\Conditions\DoesNotHaveAuraCondition.cs" />
     <Compile Include="Gambits\Conditions\DragoonGaugeTimerCondition.cs" />
     <Compile Include="Gambits\Conditions\DragoonGazeCondition.cs" />
@@ -219,6 +220,7 @@
     <Compile Include="Gambits\Conditions\GambitCondition.cs" />
     <Compile Include="Gambits\Conditions\IGambitCondition.cs" />
     <Compile Include="Gambits\Conditions\LastSpellCondition.cs" />
+    <Compile Include="Gambits\Conditions\DancerEspritCondition.cs" />
     <Compile Include="Gambits\Conditions\MachinistHeatCondition.cs" />
     <Compile Include="Gambits\Conditions\MonkChakraCondition.cs" />
     <Compile Include="Gambits\Conditions\MpPercentCondition.cs" />

--- a/Magitek/Models/Dancer/DancerSettings.cs
+++ b/Magitek/Models/Dancer/DancerSettings.cs
@@ -63,6 +63,10 @@ namespace Magitek.Models.Dancer
         [Setting]
         [DefaultValue(true)]
         public bool SaberDance { get; set; }
+
+        [Setting]
+        [DefaultValue(85)]
+        public int SaberDanceEsprit { get; set; }
         #endregion
 
         #region aoe
@@ -75,7 +79,7 @@ namespace Magitek.Models.Dancer
         public bool Windmill { get; set; }
 
         [Setting]
-        [DefaultValue(2)]
+        [DefaultValue(3)]
         public int WindmillEnemies { get; set; }
 
         [Setting]
@@ -83,7 +87,7 @@ namespace Magitek.Models.Dancer
         public bool Bladeshower { get; set; }
 
         [Setting]
-        [DefaultValue(2)]
+        [DefaultValue(3)]
         public int BladeshowerEnemies { get; set; }
 
         [Setting]
@@ -91,7 +95,7 @@ namespace Magitek.Models.Dancer
         public bool RisingWindmill { get; set; }
 
         [Setting]
-        [DefaultValue(2)]
+        [DefaultValue(3)]
         public int RisingWindmillEnemies { get; set; }
 
         [Setting]
@@ -123,7 +127,7 @@ namespace Magitek.Models.Dancer
         public bool UseCuringWaltz { get; set; }
 
         [Setting]
-        [DefaultValue(80f)]
+        [DefaultValue(40f)]
         public float CuringWaltzHP { get; set; }
 
         [Setting]

--- a/Magitek/Rotations/Dancer.cs
+++ b/Magitek/Rotations/Dancer.cs
@@ -124,7 +124,6 @@ namespace Magitek.Rotations
                 if (await Buff.UsePotion()) return true;
                 
                 //Buff
-                if (await Buff.PreTechnicalDevilment()) return true;
                 if (await Buff.Devilment()) return true;
                 if (await Buff.Flourish()) return true;
 
@@ -139,15 +138,24 @@ namespace Magitek.Rotations
                 if (await Buff.Improvisation()) return true;
             }
 
+            //GCD
             if (await Aoe.StarfallDance()) return true;
             if (await Dances.Tillana()) return true;
-            if (await SingleTarget.Fountainfall()) return true;
-            if (await SingleTarget.ReverseCascade()) return true; 
             if (await Aoe.SaberDance()) return true;
-            if (await Aoe.Bloodshower()) return true;
-            if (await Aoe.RisingWindmill()) return true;
-            if (await Aoe.Bladeshower()) return true;
-            if (await Aoe.Windmill()) return true;
+
+            //Silken Flow Aura
+            if (await Aoe.Bloodshower()) return true; //2+ ennemies
+            if (await SingleTarget.Fountainfall()) return true;
+
+            //Silken Symmetry Aura
+            if (await Aoe.RisingWindmill()) return true; //3+ ennemies
+            if (await SingleTarget.ReverseCascade()) return true;
+
+            //Multiple Target Combo
+            if (await Aoe.Bladeshower()) return true; //3+ ennemies
+            if (await Aoe.Windmill()) return true; //3+ ennemies
+
+            //Single Target Combo
             if (await SingleTarget.Fountain()) return true;
             return await SingleTarget.Cascade();
         }

--- a/Magitek/Views/UserControls/Dancer/General.xaml
+++ b/Magitek/Views/UserControls/Dancer/General.xaml
@@ -39,7 +39,7 @@
 
         <controls:SettingsBlock Margin="0 10 0 0" Background="{DynamicResource ClassSelectorBackground}">
             <StackPanel Margin="5">
-                <CheckBox Content="Use Peloton " IsChecked="{Binding BardSettings.UsePeloton, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                <CheckBox Content="Use Peloton " IsChecked="{Binding DancerSettings.UsePeloton, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
             </StackPanel>
         </controls:SettingsBlock>
 

--- a/Magitek/Views/UserControls/Dancer/SingleTarget.xaml
+++ b/Magitek/Views/UserControls/Dancer/SingleTarget.xaml
@@ -7,8 +7,8 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:sys="clr-namespace:System;assembly=mscorlib"
              xmlns:viewModels="clr-namespace:Magitek.ViewModels"
-             d:DesignHeight="400"
-             d:DesignWidth="500"
+             d:DesignHeight="500"
+             d:DesignWidth="700"
              mc:Ignorable="d">
 
     <UserControl.DataContext>
@@ -51,6 +51,11 @@
                     <CheckBox Margin="5" Content="Use Saber Dance (AOE Spell used in Single Target Rotation)" IsChecked="{Binding DancerSettings.SaberDance, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                 </StackPanel>
                 <StackPanel Orientation="Horizontal">
+                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="When not under Technical Finish, Use SaberDance if Esprit >= " />
+                    <controls:Numeric MaxValue="100" MinValue="1" Value="{Binding DancerSettings.SaberDanceEsprit, Mode=TwoWay}" />
+                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text=" (85 is recommended value)" />
+                </StackPanel>
+                <StackPanel Orientation="Horizontal">
                     <CheckBox Margin="5" Content="Use Fan Dance I" IsChecked="{Binding DancerSettings.FanDance1, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                 </StackPanel>
                 <StackPanel Orientation="Horizontal">
@@ -67,8 +72,8 @@
 
         <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
             <StackPanel Orientation="Horizontal">
-            <CheckBox Margin="5" Content="Do Not Dance/Devilment if Target Is Dying Within " IsChecked="{Binding DancerSettings.DontDotIfMultiDotTargetIsDyingSoon, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-            <controls:Numeric MaxValue="30" MinValue="1" Value="{Binding DancerSettings.DontDotIfMultiDotTargetIsDyingWithinXSeconds, Mode=TwoWay}" />
+                <CheckBox Margin="5" Content="Do Not Dance/Devilment if Target Is Dying Within " IsChecked="{Binding DancerSettings.DontDanceIfCurrentTargetIsDyingSoon, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                <controls:Numeric MaxValue="30" MinValue="1" Value="{Binding DancerSettings.DontDanceIfCurrentTargetIsDyingWithinXSeconds, Mode=TwoWay}" />
             <TextBlock Style="{DynamicResource TextBlockDefault}" Text=" Seconds" />
             </StackPanel>
         </controls:SettingsBlock>

--- a/Magitek/Views/UserControls/Machinist/Utilities.xaml
+++ b/Magitek/Views/UserControls/Machinist/Utilities.xaml
@@ -55,6 +55,12 @@
                 <ComboBox Width="170" ItemsSource="{Binding Source={StaticResource InterruptStrategy}}" SelectedValue="{Binding MachinistSettings.Strategy, Mode=TwoWay}" Style="{DynamicResource ComboBox}" />
             </StackPanel>
         </controls:SettingsBlock>
+
+        <controls:SettingsBlock Margin="0,5,0,0" Background="{DynamicResource ClassSelectorBackground}">
+            <StackPanel Margin="5" Orientation="Horizontal">
+                <CheckBox Content="Use Peloton" IsChecked="{Binding MachinistSettings.UsePeloton, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+            </StackPanel>
+        </controls:SettingsBlock>
     </StackPanel>
 </UserControl>
 


### PR DESCRIPTION
DNC:
- Settings cleaning
- Multiple Target: rotation Improvement 
- Tillana: Delay if Esprit = 100 to not waste SaberDance
- Saber Dance: usage improvement + add again capacity to define when execute SaberDance if outside TS
- Standard Step: Improve Standard Step in case of 3+ ennemies + delay if other proc inside Technical Step
- add FEATHER option in Openers to manage Fan Dance
- add ESPRIT option in Openers to manage Saber Dance
- Fix UsePeloton in Config Screen
- Fix UseRangeAndFacingChecks to properly consider the range of Huge hitbox

MCH:
- Add UsePeloton in Config Screen