### PR TITLE
PLD Optim + ForceLimitBreak on BLM/SMN + Pull Feature Fix with Kombattant

### DIFF
--- a/Magitek/Logic/Astrologian/Aoe.cs
+++ b/Magitek/Logic/Astrologian/Aoe.cs
@@ -64,11 +64,10 @@ namespace Magitek.Logic.Astrologian
             if (!AstrologianSettings.Instance.Gravity)
                 return false;
 
-            if (Core.Me.CurrentTarget == null)
+            if (!AstrologianSettings.Instance.DoDamage)
                 return false;
 
             var target = Combat.SmartAoeTarget(Spells.Gravity, AstrologianSettings.Instance.SmartAoe);
-
             if (target == null)
                 return false;
             

--- a/Magitek/Logic/Astrologian/SingleTarget.cs
+++ b/Magitek/Logic/Astrologian/SingleTarget.cs
@@ -16,6 +16,9 @@ namespace Magitek.Logic.Astrologian
             if (!AstrologianSettings.Instance.Malefic)
                 return false;
 
+            if (!AstrologianSettings.Instance.DoDamage)
+                return false;
+
             if (!Spells.Malefic.IsReady())
                 return false;
 
@@ -28,6 +31,9 @@ namespace Magitek.Logic.Astrologian
                 return false;
 
             if (!AstrologianSettings.Instance.CombustMultipleTargets)
+                return false;
+
+            if (!AstrologianSettings.Instance.DoDamage)
                 return false;
 
             var combustTarget = Combat.Enemies.FirstOrDefault(NeedsCombust);
@@ -57,6 +63,9 @@ namespace Magitek.Logic.Astrologian
         public static async Task<bool> Combust()
         {
             if (!AstrologianSettings.Instance.Combust)
+                return false;
+
+            if (!AstrologianSettings.Instance.DoDamage)
                 return false;
 
             if (!Spells.Combust.IsKnownAndReady())

--- a/Magitek/Logic/BlackMage/Aoe.cs
+++ b/Magitek/Logic/BlackMage/Aoe.cs
@@ -1,6 +1,7 @@
 ﻿using ff14bot;
 using ff14bot.Managers;
 using Magitek.Extensions;
+using Magitek.Logic.Roles;
 using Magitek.Models.BlackMage;
 using Magitek.Utilities;
 using System.Linq;
@@ -307,6 +308,15 @@ namespace Magitek.Logic.BlackMage
                 if (ActionResourceManager.BlackMage.UmbralStacks > 0)
                     return await Spells.Fire3.Cast(Core.Me.CurrentTarget);
             return false;
+        }
+
+
+        /**********************************************************************************************
+        *                              Limit Break
+        * ********************************************************************************************/
+        public static bool ForceLimitBreak()
+        {
+            return MagicDps.ForceLimitBreak(Spells.Skyshard, Spells.Starstorm, Spells.Meteor, Spells.Blizzard);
         }
     }
 }

--- a/Magitek/Logic/Gunbreaker/SingleTarget.cs
+++ b/Magitek/Logic/Gunbreaker/SingleTarget.cs
@@ -75,7 +75,7 @@ namespace Magitek.Logic.Gunbreaker
             if (!await Spells.LightningShot.Cast(lightningShotTarget))
                 return false;
 
-            Logger.WriteInfo($@"Lightning Shot On {lightningShotTarget.Name} to pull");
+            Logger.WriteInfo($@"Lightning Shot On {lightningShotTarget.Name} to pull or get back aggro");
             return true;
         }
 

--- a/Magitek/Logic/Paladin/Aoe.cs
+++ b/Magitek/Logic/Paladin/Aoe.cs
@@ -61,8 +61,8 @@ namespace Magitek.Logic.Paladin
             {
                 Aura DivineMightAura = (Core.Me as Character).Auras.FirstOrDefault(x => x.Id == Auras.DivineMight && x.CasterId == Core.Player.ObjectId);
 
-                if (Spells.FightorFlight.IsReady((int)Spells.FastBlade.AdjustedCooldown.TotalMilliseconds)
-                    && DivineMightAura != null && DivineMightAura.TimespanLeft.TotalMilliseconds >= (3 * Spells.FastBlade.AdjustedCooldown.TotalMilliseconds))
+                if (Spells.FightorFlight.IsReady((int)PaladinRoutine.GCDTimeMilliseconds)
+                    && DivineMightAura != null && DivineMightAura.TimespanLeft.TotalMilliseconds >= (3 * PaladinRoutine.GCDTimeMilliseconds))
                     return false;
             }
 
@@ -144,11 +144,11 @@ namespace Magitek.Logic.Paladin
                 if (FightOrFlightAura != null && FightOrFlightAura.TimespanLeft.TotalMilliseconds >= (4 * Spells.Confiteor.AdjustedCooldown.TotalMilliseconds))
                 {
                     var SwordOathAura = (Core.Me as Character).Auras.FirstOrDefault(x => x.Id == Auras.SwordOath && x.CasterId == Core.Player.ObjectId);
-                    if (SwordOathAura != null && SwordOathAura.TimespanLeft.TotalMilliseconds <= (3 * Spells.FastBlade.AdjustedCooldown.TotalMilliseconds))
+                    if (SwordOathAura != null && SwordOathAura.TimespanLeft.TotalMilliseconds <= (3 * PaladinRoutine.GCDTimeMilliseconds))
                         return false;
 
                     var DivineMightAura = (Core.Me as Character).Auras.FirstOrDefault(x => x.Id == Auras.DivineMight && x.CasterId == Core.Player.ObjectId);
-                    if (DivineMightAura != null && DivineMightAura.TimespanLeft.TotalMilliseconds <= (3 * Spells.FastBlade.AdjustedCooldown.TotalMilliseconds))
+                    if (DivineMightAura != null && DivineMightAura.TimespanLeft.TotalMilliseconds <= (3 * PaladinRoutine.GCDTimeMilliseconds))
                         return false;
                 }
             }

--- a/Magitek/Logic/Paladin/Buff.cs
+++ b/Magitek/Logic/Paladin/Buff.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
 using System.Threading.Tasks;
 using Auras = Magitek.Utilities.Auras;
+using PaladinRoutine = Magitek.Utilities.Routines.Paladin;
 
 namespace Magitek.Logic.Paladin
 {
@@ -37,13 +38,16 @@ namespace Magitek.Logic.Paladin
             if (!PaladinSettings.Instance.UseFightOrFlight)
                 return false;
 
-            if (ActionManager.LastSpell == Spells.FastBlade)
+            if (Spells.Requiescat.IsKnown() && !Spells.Requiescat.IsReady(1000))
                 return false;
 
-            //Force Delay CD
-            if (Spells.FastBlade.Cooldown.TotalMilliseconds > Globals.AnimationLockMs + BaseSettings.Instance.UserLatencyOffset + 100)
+            //if you're not in Range for your burst (Req Range, do not launch it
+            if (!Core.Me.CurrentTarget.WithinSpellRange(Spells.Requiescat.Range))
                 return false;
 
+            if (!PaladinRoutine.GlobalCooldown.CanDoubleWeave() || !PaladinRoutine.GlobalCooldown.CanWeave(2))
+                return false;
+ 
             return await Spells.FightorFlight.Cast(Core.Me);
 
         }

--- a/Magitek/Logic/Paladin/SingleTarget.cs
+++ b/Magitek/Logic/Paladin/SingleTarget.cs
@@ -109,12 +109,12 @@ namespace Magitek.Logic.Paladin
             {
                 Aura DivineMightAura = (Core.Me as Character).Auras.FirstOrDefault(x => x.Id == Auras.DivineMight && x.CasterId == Core.Player.ObjectId);
 
-                if (Spells.FightorFlight.IsReady(((int)Spells.FastBlade.AdjustedCooldown.TotalMilliseconds) * 2)
-                    && DivineMightAura != null && DivineMightAura.TimespanLeft.TotalMilliseconds >= (4 * Spells.FastBlade.AdjustedCooldown.TotalMilliseconds))
+                if (Spells.FightorFlight.IsReady(((int)PaladinRoutine.GCDTimeMilliseconds) * 2)
+                    && DivineMightAura != null && DivineMightAura.TimespanLeft.TotalMilliseconds >= (4 * PaladinRoutine.GCDTimeMilliseconds))
                     return false;
 
-                if (Spells.FightorFlight.IsReady((int)Spells.FastBlade.AdjustedCooldown.TotalMilliseconds)
-                    && DivineMightAura != null && DivineMightAura.TimespanLeft.TotalMilliseconds >= (3 * Spells.FastBlade.AdjustedCooldown.TotalMilliseconds))
+                if (Spells.FightorFlight.IsReady((int) PaladinRoutine.GCDTimeMilliseconds)
+                    && DivineMightAura != null && DivineMightAura.TimespanLeft.TotalMilliseconds >= (3 * PaladinRoutine.GCDTimeMilliseconds))
                     return false;
             }
             return await Spells.HolySpirit.Cast(Core.Me.CurrentTarget);
@@ -179,20 +179,14 @@ namespace Magitek.Logic.Paladin
                 Aura SwordOathAura = (Core.Me as Character).Auras.FirstOrDefault(x => x.Id == Auras.SwordOath && x.CasterId == Core.Player.ObjectId);
                 
                 if (SwordOathRemainingStack == 2 
-                    && Spells.FightorFlight.IsReady( ((int) Spells.FastBlade.AdjustedCooldown.TotalMilliseconds) * 2)
-                    && SwordOathAura != null && SwordOathAura.TimespanLeft.TotalMilliseconds >= (4 * Spells.FastBlade.AdjustedCooldown.TotalMilliseconds))
-                {
-                    Logger.Write($@"[Magitek][Info] Atonement delayed to FoF (SwordOath Stack =  {SwordOathRemainingStack} | FoF Ready  =  {Spells.FightorFlight.Cooldown.TotalSeconds} | SwordOathRemainingTime = {SwordOathAura.TimespanLeft.TotalMilliseconds})");
+                    && Spells.FightorFlight.IsReady( ((int)PaladinRoutine.GCDTimeMilliseconds) * 2)
+                    && SwordOathAura != null && SwordOathAura.TimespanLeft.TotalMilliseconds >= (4 * PaladinRoutine.GCDTimeMilliseconds))
                     return false;
-                }
                 
                 if (SwordOathRemainingStack == 1 
-                    && Spells.FightorFlight.IsReady( (int)Spells.FastBlade.AdjustedCooldown.TotalMilliseconds)
-                    && SwordOathAura != null && SwordOathAura.TimespanLeft.TotalMilliseconds >= (3 * Spells.FastBlade.AdjustedCooldown.TotalMilliseconds))
-                {
-                    Logger.Write($@"[Magitek][Info] Atonement delayed to FoF (SwordOath Stack =  {SwordOathRemainingStack} | FoF Ready in  =  {Spells.FightorFlight.Cooldown.TotalSeconds} | SwordOathRemainingTime = {SwordOathAura.TimespanLeft.TotalMilliseconds})");
+                    && Spells.FightorFlight.IsReady( (int)PaladinRoutine.GCDTimeMilliseconds)
+                    && SwordOathAura != null && SwordOathAura.TimespanLeft.TotalMilliseconds >= (3 * PaladinRoutine.GCDTimeMilliseconds))
                     return false;
-                }
             }
             return await Spells.Atonement.Cast(Core.Me.CurrentTarget);
         }

--- a/Magitek/Logic/Roles/Healer.cs
+++ b/Magitek/Logic/Roles/Healer.cs
@@ -142,6 +142,21 @@ namespace Magitek.Logic.Roles
             return false;
         }
 
+        public static async Task<bool> UsePotion<T>(T settings) where T : HealerSettings
+        {
+            if (!settings.UsePotion)
+                return false;
+
+            if (Core.Me.HasAura(Auras.Medicated, true))
+                return false;
+
+            return await Potion.UsePotion((int)settings.PotionTypeAndGradeLevel);
+        }
+
+
+        /****************************************************************************************************
+         *                                                 PVP
+         * **************************************************************************************************/
         public static async Task<bool> Recuperate<T>(T settings) where T :HealerSettings
         {
             if (!settings.Pvp_UseRecuperate)

--- a/Magitek/Logic/Roles/Tank.cs
+++ b/Magitek/Logic/Roles/Tank.cs
@@ -134,6 +134,10 @@ namespace Magitek.Logic.Roles
             return await Potion.UsePotion((int)settings.PotionTypeAndGradeLevel);
         }
 
+
+        /****************************************************************************************************
+         *                                                 PVP
+         * **************************************************************************************************/
         public static async Task<bool> Recuperate<T>(T settings) where T : TankSettings
         {
             if (!settings.Pvp_UseRecuperate)

--- a/Magitek/Logic/Summoner/Aoe.cs
+++ b/Magitek/Logic/Summoner/Aoe.cs
@@ -4,14 +4,12 @@ using ff14bot.Enums;
 using ff14bot.Managers;
 using ff14bot.Objects;
 using Magitek.Extensions;
+using Magitek.Logic.Roles;
 using Magitek.Models.Summoner;
 using Magitek.Utilities;
 using Magitek.Utilities.Routines;
-using Pathfinding;
-using System;
 using System.Linq;
 using System.Threading.Tasks;
-using System.Windows.Media.Animation;
 using ArcResources = ff14bot.Managers.ActionResourceManager.Arcanist;
 using SmnResources = ff14bot.Managers.ActionResourceManager.Summoner;
 using static Magitek.Utilities.Routines.Summoner;
@@ -320,6 +318,14 @@ namespace Magitek.Logic.Summoner
                 return false;
             
             return await Spells.Ruin4.Cast(target);
+        }
+
+        /**********************************************************************************************
+        *                              Limit Break
+        * ********************************************************************************************/
+        public static bool ForceLimitBreak()
+        {
+            return MagicDps.ForceLimitBreak(Spells.Skyshard, Spells.Starstorm, Spells.Teraflare, Spells.Ruin);
         }
     }
 }

--- a/Magitek/Models/Paladin/PaladinSettings.cs
+++ b/Magitek/Models/Paladin/PaladinSettings.cs
@@ -177,9 +177,9 @@ namespace Magitek.Models.Paladin
         [DefaultValue(true)]
         public bool InterveneOnlyInMelee { get; set; }
 
-        [Setting]
+        /*[Setting]
         [DefaultValue(0)]
-        public int SaveInterveneCharges { get; set; }
+        public int SaveInterveneCharges { get; set; }*/
         #endregion
 
         #region DefensiveGroup
@@ -206,6 +206,14 @@ namespace Magitek.Models.Paladin
         public bool UseHolySpiritWhenOutOfMeleeRange { get; set; }
 
         [Setting]
+        [DefaultValue(50.0f)]
+        public float HolySpiritWhenOutOfMeleeRangeMinMpPercent { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
+        public bool UseHolySpiritWhenOutOfMeleeRangeWithDivineMightOnly { get; set; }
+
+        [Setting]
         [DefaultValue(true)]
         public bool UseHolySpiritToPull { get; set; }
 
@@ -216,6 +224,10 @@ namespace Magitek.Models.Paladin
         [Setting]
         [DefaultValue(true)]
         public bool UseAtonement { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
+        public bool KeepHolySpiritAtonementinFoF { get; set; }
 
         [Setting]
         [DefaultValue(true)]

--- a/Magitek/Models/Roles/HealerSettings.cs
+++ b/Magitek/Models/Roles/HealerSettings.cs
@@ -1,4 +1,5 @@
 ﻿using ff14bot.Helpers;
+using Magitek.Enumerations;
 using PropertyChanged;
 using System.ComponentModel;
 using System.Configuration;
@@ -32,7 +33,11 @@ namespace Magitek.Models.Roles
 
         [Setting]
         [DefaultValue(false)]
-        public bool ForceLimitBreak { get; set; }
+        public bool UsePotion { get; set; }
+
+        [Setting]
+        [DefaultValue(PotionEnum.None)]
+        public PotionEnum PotionTypeAndGradeLevel { get; set; }
 
         [Setting]
         [DefaultValue(true)]

--- a/Magitek/Models/Roles/MagicDpsSettings.cs
+++ b/Magitek/Models/Roles/MagicDpsSettings.cs
@@ -28,6 +28,14 @@ namespace Magitek.Models.Roles
         [DefaultValue(InterruptStrategy.Never)]
         public InterruptStrategy Strategy { get; set; }
 
+        [Setting]
+        [DefaultValue(false)]
+        public bool UsePotion { get; set; }
+
+        [Setting]
+        [DefaultValue(PotionEnum.None)]
+        public PotionEnum PotionTypeAndGradeLevel { get; set; }
+
         #region pvp
         [Setting]
         [DefaultValue(true)]

--- a/Magitek/Resources/Toggles/ReaperToggles.json
+++ b/Magitek/Resources/Toggles/ReaperToggles.json
@@ -116,8 +116,8 @@
     "ExecuteToggleCommand": {},
     "AddToggleSettingCommand": {},
     "RemoveToggleSettingCommand": {},
-    "ToggleKey": 50,
-    "ToggleModifierKey": 2
+    "ToggleKey": 0,
+    "ToggleModifierKey": 0
   },
   {
     "ToggleText": "Use AOEs",
@@ -232,8 +232,8 @@
     "ExecuteToggleCommand": {},
     "AddToggleSettingCommand": {},
     "RemoveToggleSettingCommand": {},
-    "ToggleKey": 49,
-    "ToggleModifierKey": 2
+    "ToggleKey": 0,
+    "ToggleModifierKey": 0
   },
   {
     "ToggleText": "Use Soul Slice",
@@ -280,7 +280,7 @@
     "ExecuteToggleCommand": {},
     "AddToggleSettingCommand": {},
     "RemoveToggleSettingCommand": {},
-    "ToggleKey": 53,
-    "ToggleModifierKey": 2
+    "ToggleKey": 0,
+    "ToggleModifierKey": 0
   }
 ]

--- a/Magitek/Resources/Toggles/SageToggles.json
+++ b/Magitek/Resources/Toggles/SageToggles.json
@@ -302,8 +302,8 @@
     "ExecuteToggleCommand": {},
     "AddToggleSettingCommand": {},
     "RemoveToggleSettingCommand": {},
-    "ToggleKey": 51,
-    "ToggleModifierKey": 2
+    "ToggleKey": 0,
+    "ToggleModifierKey": 0
   },
   {
     "ToggleText": "Force Prognosis",
@@ -326,8 +326,8 @@
     "ExecuteToggleCommand": {},
     "AddToggleSettingCommand": {},
     "RemoveToggleSettingCommand": {},
-    "ToggleKey": 49,
-    "ToggleModifierKey": 2
+    "ToggleKey": 0,
+    "ToggleModifierKey": 0
   },
   {
     "ToggleText": "Use Druochole",
@@ -398,8 +398,8 @@
     "ExecuteToggleCommand": {},
     "AddToggleSettingCommand": {},
     "RemoveToggleSettingCommand": {},
-    "ToggleKey": 50,
-    "ToggleModifierKey": 2
+    "ToggleKey": 0,
+    "ToggleModifierKey": 0
   },
   {
     "ToggleText": "Force Panhaima",
@@ -422,8 +422,8 @@
     "ExecuteToggleCommand": {},
     "AddToggleSettingCommand": {},
     "RemoveToggleSettingCommand": {},
-    "ToggleKey": 52,
-    "ToggleModifierKey": 2
+    "ToggleKey": 0,
+    "ToggleModifierKey": 0
   },
   {
     "ToggleText": "Force Haima",
@@ -446,7 +446,7 @@
     "ExecuteToggleCommand": {},
     "AddToggleSettingCommand": {},
     "RemoveToggleSettingCommand": {},
-    "ToggleKey": 53,
-    "ToggleModifierKey": 2
+    "ToggleKey": 0,
+    "ToggleModifierKey": 0
   }
 ]

--- a/Magitek/Rotations/BlackMage.cs
+++ b/Magitek/Rotations/BlackMage.cs
@@ -98,16 +98,21 @@ namespace Magitek.Rotations
             if (BotManager.Current.IsAutonomous)
             {
                 if (Core.Me.HasTarget)
-                {
                     Movement.NavigateToUnitLos(Core.Me.CurrentTarget, 20 + Core.Me.CurrentTarget.CombatReach);
-                }
             }
 
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
+
             if (Core.Me.CurrentTarget.HasAnyAura(Auras.Invincibility))
                 return false;
-            if (await CustomOpenerLogic.Opener()) return true;
+
+            if (await CustomOpenerLogic.Opener())
+                return true;
+
+
+            //LimitBreak
+            if (Aoe.ForceLimitBreak()) return true;
 
             //DON'T CHANGE THE ORDER OF THESE
             //if (await Buff.Enochian()) return true;
@@ -120,7 +125,6 @@ namespace Magitek.Rotations
             //if (await Buff.Transpose()) return true;
 
             if (BlackMageSettings.Instance.UseAoe && Core.Me.CurrentTarget.EnemiesNearby(10).Count() >= BlackMageSettings.Instance.AoeEnemies)
-
             {
                 //Umbral
                 if (await Aoe.Freeze()) return true;
@@ -133,6 +137,7 @@ namespace Magitek.Rotations
                 if (await Aoe.Fire4()) return true;
                 if (await Aoe.Flare()) return true;
             }
+
             if (await SingleTarget.ParadoxUmbral()) return true;
             if (await SingleTarget.Blizzard4()) return true;
             if (await SingleTarget.Fire()) return true;
@@ -149,6 +154,7 @@ namespace Magitek.Rotations
 
             return false;
         }
+
         public static async Task<bool> PvP()
         {
             if (!BaseSettings.Instance.ActivePvpCombatRoutine)

--- a/Magitek/Rotations/Gunbreaker.cs
+++ b/Magitek/Rotations/Gunbreaker.cs
@@ -35,14 +35,19 @@ namespace Magitek.Rotations
             if (BotManager.Current.IsAutonomous)
             {
                 if (Core.Me.HasTarget)
-                {
                     Movement.NavigateToUnitLos(Core.Me.CurrentTarget, Core.Me.CurrentTarget.CombatReach);
-                }
             }
 
-            if (GunbreakerSettings.Instance.LightningShotToPullAggro)
-                await Spells.LightningShot.Cast(Core.Me.CurrentTarget);
+            if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
+                return false;
 
+            /*if (GunbreakerSettings.Instance.LightningShotToPullAggro)
+                await Spells.LightningShot.Cast(Core.Me.CurrentTarget);*/
+
+            if (await Casting.TrackSpellCast())
+                return true;
+
+            await Casting.CheckForSuccessfulCast();
             return await Combat();
         }
 
@@ -153,6 +158,7 @@ namespace Magitek.Rotations
 
             return await SingleTarget.KeenEdge();
         }
+
         public static async Task<bool> PvP()
         {
             if (!BaseSettings.Instance.ActivePvpCombatRoutine)

--- a/Magitek/Rotations/Paladin.cs
+++ b/Magitek/Rotations/Paladin.cs
@@ -113,36 +113,37 @@ namespace Magitek.Rotations
                     if (await Defensive.Intervention()) return true;
                     if (await Defensive.Cover()) return true;
 
+                    //Damage Buff
+                    if (await Buff.FightOrFlight()) return true;
+
                     //oGCDS
-                    if (await SingleTarget.Intervene()) return true; //dash
                     if (await SingleTarget.Requiescat()) return true;
                     if (await Aoe.CircleOfScorn()) return true;
                     if (await Aoe.Expiacion()) return true;
-
-                    //Damage Buff (was before oGCD)
-                    if (await Buff.FightOrFlight()) return true;
+                    if (await SingleTarget.Intervene()) return true; //dash
                 }
 
                 if (await SingleTarget.ShieldLobOnLostAggro()) return true;
-
-                if (await Aoe.HolyCircle()) return true;
                 if (await SingleTarget.GoringBlade()) return true;
-                if (await SingleTarget.HolySpirit()) return true;
-                if (await SingleTarget.Atonement()) return true;
-
-                //Combo Action
-                if (await Aoe.Prominence()) return true;
-                if (await SingleTarget.RoyalAuthority()) return true;
-                if (await SingleTarget.RiotBlade()) return true;
 
                 //Combo AOE (Single Target or Multi Target)
                 if (await Aoe.BladeOfValor()) return true;
                 if (await Aoe.BladeOfTruth()) return true;
                 if (await Aoe.BladeOfFaith()) return true;
                 if (await Aoe.Confiteor()) return true;
- 
-                //Basic Action
+
+                //Under Divine Might Aura to have no cast or stacks of Sword Oath
+                if (await Aoe.HolyCircle()) return true;
+                if (await SingleTarget.HolySpirit()) return true;
+                if (await SingleTarget.Atonement()) return true;
+
+                //Combo Action AOE
+                if (await Aoe.Prominence()) return true;
                 if (await Aoe.TotalEclipse()) return true;
+
+                //Combo Action Single Target
+                if (await SingleTarget.RoyalAuthority()) return true;
+                if (await SingleTarget.RiotBlade()) return true;
                 if (await SingleTarget.FastBlade()) return true;
 
                 return await SingleTarget.ShieldLob();

--- a/Magitek/Rotations/Summoner.cs
+++ b/Magitek/Rotations/Summoner.cs
@@ -44,9 +44,7 @@ namespace Magitek.Rotations
             if (BotManager.Current.IsAutonomous)
             {
                 if (Core.Me.HasTarget)
-                {
                     Movement.NavigateToUnitLos(Core.Me.CurrentTarget, 20 + Core.Me.CurrentTarget.CombatReach);
-                }
             }
 
             return await Combat();
@@ -72,10 +70,12 @@ namespace Magitek.Rotations
             return await Logic.Summoner.Heal.Physick();
 
         }
+
         public static Task<bool> CombatBuff()
         {
             return Task.FromResult(false);
         }
+
         public static async Task<bool> Combat()
         {
             if (BaseSettings.Instance.ActivePvpCombatRoutine)
@@ -84,22 +84,23 @@ namespace Magitek.Rotations
             if (BotManager.Current.IsAutonomous)
             {
                 if (Core.Me.HasTarget)
-                {
                     Movement.NavigateToUnitLos(Core.Me.CurrentTarget, 20 + Core.Me.CurrentTarget.CombatReach);
-                }
             }
 
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
 
-
-            if (await CustomOpenerLogic.Opener()) return true;
+            if (await CustomOpenerLogic.Opener())
+                return true;
 
             if (Core.Me.CurrentTarget.HasAura(Auras.MagicResistance))
                 return false;
 
             if (Core.Me.CurrentTarget.HasAnyAura(Auras.Invincibility))
                 return false;
+
+            //LimitBreak
+            if (Aoe.ForceLimitBreak()) return true;
 
             if (await Buff.LucidDreaming()) return true;
             if (await Pets.SummonCarbuncleOrEgi()) return true;

--- a/Magitek/Rotations/Warrior.cs
+++ b/Magitek/Rotations/Warrior.cs
@@ -36,10 +36,11 @@ namespace Magitek.Rotations
             if (BotManager.Current.IsAutonomous)
             {
                 if (Core.Me.HasTarget)
-                {
                     Movement.NavigateToUnitLos(Core.Me.CurrentTarget, Core.Me.CurrentTarget.CombatReach);
-                }
             }
+
+            if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
+                return false;
 
             if (await Casting.TrackSpellCast())
                 return true;
@@ -73,6 +74,9 @@ namespace Magitek.Rotations
             }
 
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
+                return false;
+
+            if (Core.Me.CurrentTarget.HasAnyAura(Auras.Invincibility))
                 return false;
 
             if (await CustomOpenerLogic.Opener())
@@ -133,6 +137,7 @@ namespace Magitek.Rotations
 
             return await SingleTarget.Tomahawk();
         }
+
         public static async Task<bool> PvP()
         {
             if (!BaseSettings.Instance.ActivePvpCombatRoutine)

--- a/Magitek/Utilities/Auras.cs
+++ b/Magitek/Utilities/Auras.cs
@@ -201,7 +201,7 @@ namespace Magitek.Utilities
             Devilment = 1825,
             ShieldSamba = 1826,
             SwordOath = 1902,
-            FightOrFight = 76,
+            FightOrFlight = 76,
             Ruination = 1291,
             Dia = 1871,
             Biolysis = 1895,

--- a/Magitek/Utilities/Routines/Paladin.cs
+++ b/Magitek/Utilities/Routines/Paladin.cs
@@ -10,6 +10,7 @@ namespace Magitek.Utilities.Routines
     internal static class Paladin
     {
         public static WeaveWindow GlobalCooldown = new WeaveWindow(ClassJobType.Paladin, Spells.FastBlade);
+        public static double GCDTimeMilliseconds = Spells.FastBlade.AdjustedCooldown.TotalMilliseconds;
 
         public static SpellData RoyalAuthority => Core.Me.ClassLevel < 60
                                                     ? Spells.RageofHalone

--- a/Magitek/Utilities/WeaveWindow.cs
+++ b/Magitek/Utilities/WeaveWindow.cs
@@ -85,6 +85,17 @@ namespace Magitek.Utilities
             return maxWeaveCount > 0;
         }
 
+        /*
+         * This method is checking if there is enough time to launch 2 oGCD in current remaining GCD Time
+         */
+        public bool CanDoubleWeave()
+        {
+            if (_gcd.IsReady((Globals.AnimationLockMs + BaseSettings.Instance.UserLatencyOffset) * 2))
+                return false;
+
+            return true;
+        }
+
         public bool CanWeaveLate(int ogcdPlacement = 1)
         {
             if (!CanWeave(ogcdPlacement))

--- a/Magitek/Views/UserControls/Paladin/Combat.xaml
+++ b/Magitek/Views/UserControls/Paladin/Combat.xaml
@@ -34,21 +34,20 @@
                 <TextBlock Style="{DynamicResource TextBlockDefault}" Text=" Single Target" />
                 <StackPanel Margin="5" Orientation="Horizontal">
                     <CheckBox Content="Intervene (Dash)  " IsChecked="{Binding PaladinSettings.UseIntervene, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                    <CheckBox Content="Only in Melee. Save " IsChecked="{Binding PaladinSettings.InterveneOnlyInMelee, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                    <controls:Numeric Margin="0,3" MaxValue="5" MinValue="0" Value="{Binding PaladinSettings.SaveInterveneCharges, Mode=TwoWay}" />
-                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text=" charges" />
+                    <CheckBox Content="Only in Melee." IsChecked="{Binding PaladinSettings.InterveneOnlyInMelee, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                 </StackPanel>
                 <StackPanel Margin="5" Orientation="Horizontal">
-                    <StackPanel Orientation="Horizontal">
-                        <CheckBox Content="Holy Spirit                       " IsChecked="{Binding PaladinSettings.UseHolySpirit, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                        <CheckBox Content="Requiescat " IsChecked="{Binding PaladinSettings.UseRequiescat, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                    </StackPanel>
+                    <CheckBox Content="GoringBlade" IsChecked="{Binding PaladinSettings.UseGoringBlade, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                 </StackPanel>
                 <StackPanel Margin="5" Orientation="Horizontal">
-                    <StackPanel Orientation="Horizontal">
-                        <CheckBox Content="GoringBlade                    " IsChecked="{Binding PaladinSettings.UseGoringBlade, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                        <CheckBox Content="Atonement " IsChecked="{Binding PaladinSettings.UseAtonement, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                    </StackPanel>
+                    <CheckBox Content="Requiescat " IsChecked="{Binding PaladinSettings.UseRequiescat, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                </StackPanel>
+                <StackPanel Margin="5" Orientation="Horizontal">
+                    <CheckBox Content="Holy Spirit            " IsChecked="{Binding PaladinSettings.UseHolySpirit, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <CheckBox Content="Atonement " IsChecked="{Binding PaladinSettings.UseAtonement, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                </StackPanel>
+                <StackPanel Margin="25 0 0 0" Orientation="Horizontal">
+                    <CheckBox Content="Keep Atonement and HolySpirit in FOF (Experimental)" IsChecked="{Binding PaladinSettings.KeepHolySpiritAtonementinFoF, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                 </StackPanel>
             </StackPanel>
         </controls:SettingsBlock>
@@ -57,10 +56,16 @@
             <StackPanel Margin="5">
                 <TextBlock Style="{DynamicResource TextBlockDefault}" Text=" When Target is out of Melee Range" />
                 <StackPanel Margin="5" Orientation="Horizontal">
-                    <CheckBox Content="Use HolySpirit                 " IsChecked="{Binding PaladinSettings.UseHolySpiritWhenOutOfMeleeRange, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                    <CheckBox Content="Use ShieldLob"                   IsChecked="{Binding PaladinSettings.UseShieldLob, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <CheckBox Content="Use HolySpirit as long as Mana is >= " IsChecked="{Binding PaladinSettings.UseHolySpiritWhenOutOfMeleeRange, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <controls:Numeric Increment="5" MaxValue="100" MinValue="1" Value="{Binding PaladinSettings.HolySpiritWhenOutOfMeleeRangeMinMpPercent, Mode=TwoWay}" />
                 </StackPanel>
+                <StackPanel Margin="25 0 0 0" Orientation="Horizontal">
+                    <CheckBox Content=" Only under Divine Might Aura." IsChecked="{Binding PaladinSettings.UseHolySpiritWhenOutOfMeleeRangeWithDivineMightOnly, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                </StackPanel>
+                <StackPanel Margin="5" Orientation="Horizontal">
+                    <CheckBox Content="Use ShieldLob" IsChecked="{Binding PaladinSettings.UseShieldLob, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
             </StackPanel>
+    </StackPanel>
         </controls:SettingsBlock>
 
         <controls:SettingsBlock Margin="0,5,0,0" Background="{DynamicResource ClassSelectorBackground}">
@@ -93,7 +98,7 @@
                 </StackPanel>
                 <StackPanel Margin="5">
                     <StackPanel Orientation="Horizontal">
-                        <CheckBox Content="Use Expiacon / Spirits Within" IsChecked="{Binding PaladinSettings.UseExpiacion, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                        <CheckBox Content="Use Expiacion / Spirits Within" IsChecked="{Binding PaladinSettings.UseExpiacion, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                     </StackPanel>
                 </StackPanel>
                 <StackPanel Grid.Row="2" Margin="5">


### PR DESCRIPTION
- PLD: Rework rotation according to last feedback
- PLD: Implement a control on FoF in case you're not in melee range
- PLD: Implement Holy Spirit/Shield Lob logic when you're not in melee range (new options available in UI)
- PLD: 6.4 Optimization to use HolySpirit/HolyCircle/Atonement inside FoF when possible (Toggle To activate or deactivate if required)
- BLM: Add ForceLimitBreak Feature
- SMN: Add ForceLimitBreak Feature
- AST: Fix Do Damage settings which was not taken into account
- AST: Fix Pull for Kombattant which not check if target can attack
- WHM: Fix Pull for Kombattant which not check if target can attack
- SGE: Fix Pull for Kombattant which not check if target can attack
- SCH: Fix Pull for Kombattant which not check if target can attack
- GNB: Fix Pull for Kombattant which not check if target can attack