### PR TITLE
fix: casting lucid dreaming on dummies.

### DIFF
--- a/Magitek/Logic/Roles/Healer.cs
+++ b/Magitek/Logic/Roles/Healer.cs
@@ -30,7 +30,7 @@ namespace Magitek.Logic.Roles
             if (Spells.LucidDreaming.Cooldown != TimeSpan.Zero)
                 return false;
 
-            if (Combat.CombatTotalTimeLeft <= 20)
+            if (Core.Me.CurrentTarget.CombatTimeLeft() <= 20)
                 return false;
 
             return await Spells.LucidDreaming.CastAura(Core.Me, Auras.LucidDreaming);


### PR DESCRIPTION
Before the combatTime is always 0  because we are fighting dummy but with this fix. It should account for the dummies. 