### PR TITLE
Some updates

### DIFF
--- a/Magitek/Controls/OpenersControl.xaml
+++ b/Magitek/Controls/OpenersControl.xaml
@@ -139,7 +139,7 @@
 
                                                             <Rectangle Grid.Column="1" Width="2" VerticalAlignment="Stretch" Fill="Black" Opacity="0.10" />
 
-                                                            <CheckBox Grid.Column="2" Margin="3" Content="" IsChecked="{Binding IsActive, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                                                            <CheckBox Grid.Column="2" Margin="3" Content="" IsChecked="{Binding IsActive, Mode=TwoWay}" Style="{DynamicResource CheckBoxIsActiveFlat}" />
 
                                                             <TextBox Grid.Column="3"
                                                                      VerticalAlignment="Top"
@@ -1699,12 +1699,12 @@
                                                                             <ColumnDefinition Width="17" />
                                                                             <ColumnDefinition Width="17" />
                                                                             <ColumnDefinition Width="30" />
-                                                                            <ColumnDefinition Width="100" />
+                                                                            <ColumnDefinition Width="Auto" />
+                                                                            <ColumnDefinition Width="150" />
                                                                             <ColumnDefinition Width="Auto" />
                                                                             <ColumnDefinition Width="38" />
                                                                             <ColumnDefinition Width="Auto" />
                                                                             <ColumnDefinition />
-                                                                            <ColumnDefinition Width="Auto" />
                                                                             <ColumnDefinition Width="Auto" />
                                                                             <ColumnDefinition Width="Auto" />
                                                                         </Grid.ColumnDefinitions>
@@ -1739,9 +1739,18 @@
                                                                             <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="{DynamicResource Light}" Text="{Binding Order, Mode=TwoWay}" />
                                                                         </Grid>
 
+                                                                        <!--  Gambit Enabled/Disabled  -->
+                                                                        <CheckBox Grid.Row="1" 
+                                                                                  Grid.Column="3" 
+                                                                                  Margin="2,0,0,0"
+                                                                                  Content="" 
+                                                                                  HorizontalAlignment="Right"
+                                                                                  IsChecked="{Binding IsEnabled, Mode=TwoWay}" 
+                                                                                  Style="{DynamicResource CheckBoxIsActiveFlat}" />
+                                                                        
                                                                         <!--  Name  -->
                                                                         <TextBox Grid.Row="1"
-                                                                                 Grid.Column="3"
+                                                                                 Grid.Column="4"
                                                                                  CaretBrush="White"
                                                                                  Foreground="{DynamicResource GrayDark}"
                                                                                  Template="{DynamicResource TextBoxTemplateGambit}"
@@ -1750,7 +1759,7 @@
                                                                         <!--  Action Type  -->
                                                                         <ComboBox Name="GambitActionType"
                                                                                   Grid.Row="1"
-                                                                                  Grid.Column="4"
+                                                                                  Grid.Column="5"
                                                                                   Margin="5,0,2,0"
                                                                                   HorizontalAlignment="Center"
                                                                                   FontSize="9"
@@ -1785,7 +1794,7 @@
                                                                         </ComboBox>
 
                                                                         <!--  Gambit Action Settings Button  -->
-                                                                        <ComboBox Grid.Row="1" Grid.Column="5" Margin="3,0,2,0" HorizontalAlignment="Center">
+                                                                        <ComboBox Grid.Row="1" Grid.Column="6" Margin="3,0,2,0" HorizontalAlignment="Center">
                                                                             <ComboBox.Style>
                                                                                 <Style TargetType="{x:Type ComboBox}">
 
@@ -2036,7 +2045,7 @@
                                                                         </ComboBox>
 
                                                                         <!--  Conditions  -->
-                                                                        <ItemsControl Grid.Row="1" Grid.Column="6" Margin="5,0,0,0" ItemsSource="{Binding Conditions}">
+                                                                        <ItemsControl Grid.Row="1" Grid.Column="7" Margin="5,0,0,0" ItemsSource="{Binding Conditions}">
                                                                             <ItemsControl.ItemsPanel>
                                                                                 <ItemsPanelTemplate>
                                                                                     <!--  Make the items display horizontally  -->
@@ -2046,7 +2055,7 @@
 
                                                                             <ItemsControl.Resources>
                                                                                 <DataTemplate DataType="{x:Type conditions:EnemyCastingSpellCondition}">
-                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Success}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="ENEMY CASTING">
+                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Info}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="ENEMY CASTING">
                                                                                         <StackPanel Width="200" Margin="3">
                                                                                             <TextBox CaretBrush="White"
                                                                                                      FontSize="10"
@@ -2082,7 +2091,7 @@
                                                                                 </DataTemplate>
 
                                                                                 <DataTemplate DataType="{x:Type conditions:SpellOffCooldownCondition}">
-                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Success}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="SPELL OFF CD">
+                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Info}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="SPELL OFF CD">
                                                                                         <StackPanel Width="200" Margin="3">
                                                                                             <TextBox CaretBrush="White"
                                                                                                      FontSize="10"
@@ -2106,7 +2115,7 @@
                                                                                 </DataTemplate>
 
                                                                                 <DataTemplate DataType="{x:Type conditions:CountdownTimerCondition}">
-                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Success}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="COUNTDOWN TIMER">
+                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Info}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="COUNTDOWN TIMER">
                                                                                         <StackPanel Width="200" Margin="3">
                                                                                             <TextBox CaretBrush="White"
                                                                                                      FontSize="10"
@@ -2128,7 +2137,7 @@
                                                                                 </DataTemplate>
 
                                                                                 <DataTemplate DataType="{x:Type conditions:LastSpellCondition}">
-                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Success}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="LAST SPELL">
+                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Info}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="LAST SPELL">
                                                                                         <StackPanel Width="200" Margin="3">
                                                                                             <TextBox CaretBrush="White"
                                                                                                      FontSize="10"
@@ -2150,7 +2159,7 @@
                                                                                 </DataTemplate>
 
                                                                                 <DataTemplate DataType="{x:Type conditions:TargetNameCondition}">
-                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Success}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="TARGET NAME">
+                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Info}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="TARGET NAME">
                                                                                         <StackPanel Width="200" Margin="3">
                                                                                             <TextBox CaretBrush="White"
                                                                                                      FontSize="10"
@@ -2171,7 +2180,7 @@
                                                                                 </DataTemplate>
 
                                                                                 <DataTemplate DataType="{x:Type conditions:HasAuraCondition}">
-                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Success}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="TARGET HAS AURA">
+                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Info}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="TARGET HAS AURA">
                                                                                         <StackPanel Width="200">
                                                                                             <TextBox CaretBrush="White"
                                                                                                      FontSize="10"
@@ -2212,7 +2221,7 @@
                                                                                 </DataTemplate>
 
                                                                                 <DataTemplate DataType="{x:Type conditions:PlayerHasAuraCondition}">
-                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Success}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="PLAYER HAS AURA">
+                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Info}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="PLAYER HAS AURA">
                                                                                         <StackPanel Width="200">
                                                                                             <TextBox CaretBrush="White"
                                                                                                      FontSize="10"
@@ -2253,7 +2262,7 @@
                                                                                 </DataTemplate>
 
                                                                                 <DataTemplate DataType="{x:Type conditions:PlayerDoesNotHaveAuraCondition}">
-                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Success}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="PLAYER NO AURA">
+                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Info}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="PLAYER NO AURA">
                                                                                         <StackPanel Width="200">
                                                                                             <TextBox CaretBrush="White"
                                                                                                      FontSize="10"
@@ -2283,7 +2292,7 @@
                                                                                 </DataTemplate>
 
                                                                                 <DataTemplate DataType="{x:Type conditions:DoesNotHaveAuraCondition}">
-                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Success}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="NO AURA">
+                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Info}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="NO AURA">
                                                                                         <StackPanel Width="200">
                                                                                             <TextBox CaretBrush="White"
                                                                                                      FontSize="10"
@@ -2313,7 +2322,7 @@
                                                                                 </DataTemplate>
 
                                                                                 <DataTemplate DataType="{x:Type conditions:HpPercentBelowCondition}">
-                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Success}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="HP % BELOW">
+                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Info}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="HP % BELOW">
                                                                                         <StackPanel>
                                                                                             <TextBox CaretBrush="White"
                                                                                                      FontSize="10"
@@ -2334,7 +2343,7 @@
                                                                                 </DataTemplate>
 
                                                                                 <DataTemplate DataType="{x:Type conditions:HpPercentBetweenCondition}">
-                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Success}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="HP % BETWEEN">
+                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Info}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="HP % BETWEEN">
                                                                                         <StackPanel>
                                                                                             <TextBox CaretBrush="White"
                                                                                                      FontSize="10"
@@ -2361,7 +2370,7 @@
                                                                                 </DataTemplate>
 
                                                                                 <DataTemplate DataType="{x:Type conditions:InInstanceCondition}">
-                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Success}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="IN INSTANCE">
+                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Info}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="IN INSTANCE">
                                                                                         <StackPanel>
                                                                                             <TextBox CaretBrush="White"
                                                                                                      FontSize="10"
@@ -2382,7 +2391,7 @@
                                                                                 </DataTemplate>
 
                                                                                 <DataTemplate DataType="{x:Type conditions:HasPetCondition}">
-                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Success}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="HAS PET">
+                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Info}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="HAS PET">
                                                                                         <StackPanel>
                                                                                             <TextBox CaretBrush="White"
                                                                                                      FontSize="10"
@@ -2403,7 +2412,7 @@
                                                                                 </DataTemplate>
 
                                                                                 <DataTemplate DataType="{x:Type conditions:PlayerInCombatCondition}">
-                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Success}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="IN COMBAT">
+                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Info}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="IN COMBAT">
                                                                                         <StackPanel>
                                                                                             <TextBox CaretBrush="White"
                                                                                                      FontSize="10"
@@ -2424,7 +2433,7 @@
                                                                                 </DataTemplate>
 
                                                                                 <DataTemplate DataType="{x:Type conditions:PlayerNotInCombatCondition}">
-                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Success}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="NO COMBAT">
+                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Info}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="NO COMBAT">
                                                                                         <StackPanel>
                                                                                             <TextBox CaretBrush="White"
                                                                                                      FontSize="10"
@@ -2445,7 +2454,7 @@
                                                                                 </DataTemplate>
 
                                                                                 <DataTemplate DataType="{x:Type conditions:IsJobCondition}">
-                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Success}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="IS JOB">
+                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Info}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="IS JOB">
                                                                                         <StackPanel>
                                                                                             <StackPanel Orientation="Horizontal">
                                                                                                 <StackPanel>
@@ -2481,7 +2490,7 @@
                                                                                 </DataTemplate>
 
                                                                                 <DataTemplate DataType="{x:Type conditions:IsRoleCondition}">
-                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Success}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="IS ROLE">
+                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Info}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="IS ROLE">
                                                                                         <StackPanel Width="150">
                                                                                             <CheckBox Margin="3,0,0,0" Content="IS TANK" IsChecked="{Binding IsTank, Mode=TwoWay}" Style="{DynamicResource CheckBoxGambits}" />
                                                                                             <CheckBox Margin="3,3" Content="IS HEALER" IsChecked="{Binding IsHealer, Mode=TwoWay}" Style="{DynamicResource CheckBoxGambits}" />
@@ -2499,7 +2508,7 @@
                                                                                 </DataTemplate>
 
                                                                                 <DataTemplate DataType="{x:Type conditions:EnemiesNearbyCondition}">
-                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Success}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="ENEMIES NEARBY">
+                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Info}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="ENEMIES NEARBY">
                                                                                         <StackPanel Width="200">
                                                                                             <TextBox CaretBrush="White"
                                                                                                      FontSize="10"
@@ -2534,7 +2543,7 @@
                                                                                 </DataTemplate>
 
                                                                                 <DataTemplate DataType="{x:Type conditions:TargetIsBossCondition}">
-                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Success}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="TARGET BOSS">
+                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Info}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="TARGET BOSS">
                                                                                         <StackPanel Width="200">
 
                                                                                             <TextBox CaretBrush="White"
@@ -2557,7 +2566,7 @@
                                                                                 </DataTemplate>
                                                                                 
                                                                                 <DataTemplate DataType="{x:Type conditions:MonkChakraCondition}">
-                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Success}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="CHAKRA">
+                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Info}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="CHAKRA">
                                                                                         <StackPanel Width="200">
                                                                                             <TextBox CaretBrush="White"
                                                                                                      FontSize="10"
@@ -2585,7 +2594,7 @@
                                                                                 </DataTemplate>
 
                                                                                 <DataTemplate DataType="{x:Type conditions:BardRepertoireCondition}">
-                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Success}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="REPERTOIRE">
+                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Info}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="REPERTOIRE">
                                                                                         <StackPanel Width="200">
                                                                                             <TextBox CaretBrush="White"
                                                                                                      FontSize="10"
@@ -2613,7 +2622,7 @@
                                                                                 </DataTemplate>
 
                                                                                 <DataTemplate DataType="{x:Type conditions:MachinistHeatCondition}">
-                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Success}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="HEAT">
+                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Info}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="HEAT">
                                                                                         <StackPanel Width="200">
                                                                                             <TextBox CaretBrush="White"
                                                                                                      FontSize="10"
@@ -2641,7 +2650,7 @@
                                                                                 </DataTemplate>
 
                                                                                 <DataTemplate DataType="{x:Type conditions:DancerEspritCondition}">
-                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Success}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="ESPRIT">
+                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Info}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="ESPRIT">
                                                                                         <StackPanel Width="200">
                                                                                             <TextBox CaretBrush="White"
                                                                                                      FontSize="10"
@@ -2669,7 +2678,7 @@
                                                                                 </DataTemplate>
 
                                                                                 <DataTemplate DataType="{x:Type conditions:DancerFeatherCondition}">
-                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Success}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="FEATHER">
+                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Info}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="FEATHER">
                                                                                         <StackPanel Width="200">
                                                                                             <TextBox CaretBrush="White"
                                                                                                      FontSize="10"
@@ -2697,7 +2706,7 @@
                                                                                 </DataTemplate>
 
                                                                                 <DataTemplate DataType="{x:Type conditions:DragoonGazeCondition}">
-                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Success}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="GAZE">
+                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Info}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="GAZE">
                                                                                         <StackPanel Width="200">
                                                                                             <TextBox CaretBrush="White"
                                                                                                      FontSize="10"
@@ -2725,7 +2734,7 @@
                                                                                 </DataTemplate>
 
                                                                                 <DataTemplate DataType="{x:Type conditions:DragoonGaugeTimerCondition}">
-                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Success}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="DRAGOON GAUGE">
+                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Info}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="DRAGOON GAUGE">
                                                                                         <StackPanel Width="200">
                                                                                             <TextBox CaretBrush="White"
                                                                                                      FontSize="10"
@@ -2753,7 +2762,7 @@
                                                                                 </DataTemplate>
 
                                                                                 <DataTemplate DataType="{x:Type conditions:NinjaHutonCondition}">
-                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Success}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="HUTON">
+                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Info}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="HUTON">
                                                                                         <StackPanel Width="200">
                                                                                             <TextBox CaretBrush="White"
                                                                                                      FontSize="10"
@@ -2782,7 +2791,7 @@
 
 
                                                                                 <DataTemplate DataType="{x:Type conditions:NinjaNinkiCondition}">
-                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Success}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="NINKI">
+                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Info}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="NINKI">
                                                                                         <StackPanel Width="200">
                                                                                             <TextBox CaretBrush="White"
                                                                                                      FontSize="10"
@@ -2811,7 +2820,7 @@
 
 
                                                                                 <DataTemplate DataType="{x:Type conditions:SamuraiKenkiCondition}">
-                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Success}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="KENKI">
+                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Info}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="KENKI">
                                                                                         <StackPanel Width="200">
                                                                                             <TextBox CaretBrush="White"
                                                                                                      FontSize="10"
@@ -2839,7 +2848,7 @@
                                                                                 </DataTemplate>
 
                                                                                 <DataTemplate DataType="{x:Type conditions:SamuraiSenCondition}">
-                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Success}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="SEN">
+                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Info}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="SEN">
                                                                                         <StackPanel Width="250">
                                                                                             <StackPanel Orientation="Horizontal">
                                                                                                 <CheckBox Margin="3" Content="HAS GETSU" IsChecked="{Binding HasGetsu, Mode=TwoWay}" Style="{DynamicResource CheckBoxGambits}" />
@@ -2860,7 +2869,7 @@
                                                                                 </DataTemplate>
 
                                                                                 <DataTemplate DataType="{x:Type conditions:NotInInstanceCondition}">
-                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Success}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="NOT IN INSTANCE">
+                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Info}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="NOT IN INSTANCE">
                                                                                         <StackPanel>
                                                                                             <TextBox CaretBrush="White"
                                                                                                      FontSize="10"
@@ -2885,7 +2894,7 @@
                                                                         </ItemsControl>
 
                                                                         <!--  Gambit Add Conditions Button  -->
-                                                                        <ComboBox Grid.Row="1" Grid.Column="7" Margin="3,0,0,0" HorizontalAlignment="Left" Style="{DynamicResource ComboBoxGambitAddCondition}">
+                                                                        <ComboBox Grid.Row="1" Grid.Column="8" Margin="3,0,0,0" HorizontalAlignment="Left" Style="{DynamicResource ComboBoxGambitAddCondition}">
                                                                             <StackPanel>
                                                                                 <StackPanel Margin="3" Orientation="Horizontal">
                                                                                     <StackPanel>
@@ -3389,15 +3398,7 @@
                                                                                 </StackPanel>
                                                                             </StackPanel>
                                                                         </ComboBox>
-
-                                                                        <!--  Gambit Enabled/Disabled  -->
-                                                                        <CheckBox Grid.Row="1" 
-                                                                                  Grid.Column="8" 
-                                                                                  Content="" 
-                                                                                  HorizontalAlignment="Right"
-                                                                                  IsChecked="{Binding IsEnabled, Mode=TwoWay}" 
-                                                                                  Style="{DynamicResource CheckBoxFlat}" />
-                                                                        
+                                                                       
                                                                         <!--  Gambit Extra Settings Button  -->
                                                                         <ComboBox Grid.Row="1" Grid.Column="9" Margin="3,0,0,0" HorizontalAlignment="Right" Style="{DynamicResource ComboBoxGambitAdditionalSettings}">
                                                                             <StackPanel Margin="3">

--- a/Magitek/Controls/OpenersControl.xaml
+++ b/Magitek/Controls/OpenersControl.xaml
@@ -121,6 +121,7 @@
                                                                 <ColumnDefinition Width="Auto" />
                                                                 <ColumnDefinition Width="Auto" />
                                                                 <ColumnDefinition Width="Auto" />
+                                                                <ColumnDefinition Width="Auto" />
                                                                 <ColumnDefinition />
                                                                 <ColumnDefinition Width="Auto" />
                                                                 <ColumnDefinition Width="Auto" />
@@ -138,7 +139,9 @@
 
                                                             <Rectangle Grid.Column="1" Width="2" VerticalAlignment="Stretch" Fill="Black" Opacity="0.10" />
 
-                                                            <TextBox Grid.Column="2"
+                                                            <CheckBox Grid.Column="2" Margin="3" Content="" IsChecked="{Binding IsActive, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+
+                                                            <TextBox Grid.Column="3"
                                                                      VerticalAlignment="Top"
                                                                      IsReadOnly="True"
                                                                      CaretBrush="White"
@@ -148,7 +151,7 @@
                                                                      Template="{DynamicResource TextBoxTemplateGambitConditionTitleTextBox}"
                                                                      Text="{Binding Id, Mode=TwoWay}" />
                                                             
-                                                            <TextBox Grid.Column="3"
+                                                            <TextBox Grid.Column="4"
                                                                      VerticalAlignment="Top"
                                                                      CaretBrush="White"
                                                                      FontSize="11"
@@ -157,7 +160,7 @@
                                                                      Template="{DynamicResource TextBoxTemplateGambitConditionTitleTextBox}"
                                                                      Text="{Binding Name, Mode=TwoWay}" />
 
-                                                            <ComboBox Grid.Column="4" Margin="10,0,10,1" HorizontalAlignment="Right">
+                                                            <ComboBox Grid.Column="5" Margin="10,0,10,1" HorizontalAlignment="Right">
                                                                 <ComboBox.Style>
                                                                     <Style TargetType="{x:Type ComboBox}">
                                                                         <Setter Property="SnapsToDevicePixels" Value="True" />
@@ -248,7 +251,7 @@
                                                                 </StackPanel>
                                                             </ComboBox>
 
-                                                            <TextBox Grid.Column="5"
+                                                            <TextBox Grid.Column="6"
                                                                      VerticalAlignment="Top"
                                                                      CaretBrush="White"
                                                                      FontSize="11"
@@ -257,7 +260,7 @@
                                                                      Template="{DynamicResource TextBoxTemplateGambitConditionTitleTextBox}"
                                                                      Text="{Binding ZoneId, Mode=TwoWay}" />
 
-                                                            <TextBox Grid.Column="6"
+                                                            <TextBox Grid.Column="7"
                                                                      VerticalAlignment="Top"
                                                                      CaretBrush="White"
                                                                      FontSize="11"
@@ -266,9 +269,9 @@
                                                                      Template="{DynamicResource TextBoxTemplateGambitConditionTitleTextBox}"
                                                                      Text="{Binding ZoneName, Mode=TwoWay}" />
 
-                                                            <CheckBox Grid.Column="7" Margin="3" Content="USE ONLY ONCE PER COMBAT" IsChecked="{Binding OnlyUseOncePerCombat, Mode=TwoWay}" Style="{DynamicResource CheckBoxGambits}" />
+                                                            <CheckBox Grid.Column="8" Margin="3" Content="USE ONLY ONCE PER COMBAT" IsChecked="{Binding OnlyUseOncePerCombat, Mode=TwoWay}" Style="{DynamicResource CheckBoxGambits}" />
 
-                                                            <Button Grid.Column="8"
+                                                            <Button Grid.Column="9"
                                                                     Margin="5,0,0,1"
                                                                     HorizontalAlignment="Right"
                                                                     Command="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}, Path=DataContext.SetOpenerGroupCurrentZone}"
@@ -277,7 +280,7 @@
                                                                     ToolTip="Set Opener To Current Zone"
                                                                     Visibility="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Expander}}, Path=IsExpanded, Converter={StaticResource BoolToVis}}" />
 
-                                                            <Button Grid.Column="9"
+                                                            <Button Grid.Column="10"
                                                                     Margin="5,0,0,1"
                                                                     HorizontalAlignment="Right"
                                                                     Command="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}, Path=DataContext.AddGambit}"
@@ -286,7 +289,7 @@
                                                                     ToolTip="Add Action"
                                                                     Visibility="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Expander}}, Path=IsExpanded, Converter={StaticResource BoolToVis}}" />
 
-                                                            <ComboBox Grid.Column="10" Margin="5,0,0,1" HorizontalAlignment="Right" Style="{DynamicResource ComboBoxGambitAdditionalSettings}">
+                                                            <ComboBox Grid.Column="11" Margin="5,0,0,1" HorizontalAlignment="Right" Style="{DynamicResource ComboBoxGambitAdditionalSettings}">
                                                                 <StackPanel Margin="3">
 
                                                                     <!--  Shared Gambit Group  -->

--- a/Magitek/Gambits/OpenerGroup.cs
+++ b/Magitek/Gambits/OpenerGroup.cs
@@ -8,6 +8,7 @@ namespace Magitek.Gambits
     [AddINotifyPropertyChangedInterface]
     public class OpenerGroup
     {
+        public bool IsActive { get; set; }
         public string Name { get; set; }
         public int Id { get; set; } = 1;
         public int ZoneId { get; set; }

--- a/Magitek/Logic/CustomOpenerLogic.cs
+++ b/Magitek/Logic/CustomOpenerLogic.cs
@@ -184,6 +184,9 @@ namespace Magitek.Logic
             // Look for an Opener that meets the opening conditions
             foreach (var opener in OpenerGroups)
             {
+                if (!opener.IsActive)
+                    continue;
+
                 if (opener.Gambits.Count == 0)
                     continue;
 

--- a/Magitek/Logic/Dancer/Buff.cs
+++ b/Magitek/Logic/Dancer/Buff.cs
@@ -1,4 +1,5 @@
-﻿using ff14bot;
+﻿using Buddy.Coroutines;
+using ff14bot;
 using ff14bot.Enums;
 using ff14bot.Managers;
 using ff14bot.Objects;
@@ -7,7 +8,6 @@ using Magitek.Extensions;
 using Magitek.Logic.Roles;
 using Magitek.Models.Dancer;
 using Magitek.Utilities;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -17,6 +17,7 @@ namespace Magitek.Logic.Dancer
 {
     internal static class Buff
     {
+        private static uint[] FlourishingAuras = { Auras.FlourishingSymmetry, Auras.FlourishingFlow, Auras.ThreefoldFanDance, Auras.FourfoldFanDance };
 
         /************************************************************************************************************************
          *                                                 Damage
@@ -29,22 +30,8 @@ namespace Magitek.Logic.Dancer
             if (Core.Me.HasAura(Auras.StandardStep) || Core.Me.HasAura(Auras.TechnicalStep))
                 return false;
 
-            if (DancerSettings.Instance.DevilmentWithTechnicalStep)
-            {
-                if (ActionManager.HasSpell(Spells.TechnicalStep.Id) && Spells.TechnicalStep.Cooldown > TimeSpan.FromMilliseconds(1000))
-                    return false;
-
-                if (!Core.Me.HasAura(Auras.StandardFinish))
-                    return false;
-            }
-            else
-            {
-                if (Spells.StandardStep.IsKnownAndReady())
-                    return false;
-
-                if (Spells.TechnicalStep.IsKnownAndReady())
-                    return false;
-            }
+            if (Casting.LastSpell != Spells.QuadrupleTechnicalFinish)
+                return false;
 
             return await Spells.Devilment.Cast(Core.Me);
         }
@@ -66,11 +53,8 @@ namespace Magitek.Logic.Dancer
             if (Spells.TechnicalStep.IsKnownAndReady())
                 return false;
 
-            if (DancerSettings.Instance.DevilmentWithFlourish)
-            {
-                if (Spells.Devilment.IsKnownAndReady())
-                    return false;
-            }
+            if (Spells.Devilment.IsKnownAndReady())
+                return false;
 
             if (Core.Me.HasAura(Auras.StandardStep) || Core.Me.HasAura(Auras.TechnicalStep))
                 return false;
@@ -119,8 +103,6 @@ namespace Magitek.Logic.Dancer
             return await Spells.Improvisation.Cast(Core.Me);
         }
 
-        private static uint[] FlourishingAuras = { Auras.FlourishingSymmetry, Auras.FlourishingFlow, Auras.ThreefoldFanDance, Auras.FourfoldFanDance };
-
 
         /************************************************************************************************************************
          *                                                 Dance Partner
@@ -130,7 +112,6 @@ namespace Magitek.Logic.Dancer
             if (!DancerSettings.Instance.UseClosedPosition)
                 return false;
 
-           // Logger.Write($@"[Magitek] Has Dance Partner : {Core.Me.HasAura(Auras.ClosedPosition)}");
             if (Core.Me.HasAura(Auras.ClosedPosition))
                 return false;
 

--- a/Magitek/Logic/Dancer/SingleTarget.cs
+++ b/Magitek/Logic/Dancer/SingleTarget.cs
@@ -16,15 +16,16 @@ namespace Magitek.Logic.Dancer
             if (!DancerSettings.Instance.FanDance1)
                 return false;
 
-            if (ActionResourceManager.Dancer.FourFoldFeathers < 4 && !Core.Me.HasAura(Auras.Devilment) && Core.Me.ClassLevel >= 62) return false;
-
-            if (Combat.Enemies.Count(r => r.Distance(Core.Me) <= 5 + r.CombatReach) >= DancerSettings.Instance.FanDanceTwoEnemies) return false;
+            if (ActionResourceManager.Dancer.FourFoldFeathers < 4 && !Core.Me.HasAura(Auras.Devilment) && Core.Me.ClassLevel >= 62) 
+                return false;
 
             if (DancerSettings.Instance.UseRangeAndFacingChecks)
             {
-                if (Core.Me.HasAura(Auras.StandardStep) || Core.Me.HasAura(Auras.TechnicalStep)) return false;
-                //if (Core.Me.CurrentTarget.Distance(Core.Me) > Spells.FanDance.Range) return false;
-                if (!GameSettingsManager.FaceTargetOnAction && !Core.Me.CurrentTarget.InView()) return false;
+                if (Core.Me.HasAura(Auras.StandardStep) || Core.Me.HasAura(Auras.TechnicalStep)) 
+                    return false;
+
+                if (!GameSettingsManager.FaceTargetOnAction && !Core.Me.CurrentTarget.InView()) 
+                    return false;
             }
 
             return await Spells.FanDance.Cast(Core.Me.CurrentTarget);

--- a/Magitek/Models/Dancer/DancerSettings.cs
+++ b/Magitek/Models/Dancer/DancerSettings.cs
@@ -19,14 +19,6 @@ namespace Magitek.Models.Dancer
         public bool UseDevilment { get; set; }
 
         [Setting]
-        [DefaultValue(false)]
-        public bool DevilmentWithFlourish { get; set; }
-
-        [Setting]
-        [DefaultValue(true)]
-        public bool DevilmentWithTechnicalStep { get; set; }
-
-        [Setting]
         [DefaultValue(true)]
         public bool UseFlourish { get; set; }
         #endregion

--- a/Magitek/Rotations/BlueMage.cs
+++ b/Magitek/Rotations/BlueMage.cs
@@ -62,9 +62,6 @@ namespace Magitek.Rotations
 
         public static async Task<bool> Combat()
         {
-            if (await GambitLogic.Gambit())
-                return true;
-
             if (!SpellQueueLogic.SpellQueue.Any())
             {
                 SpellQueueLogic.InSpellQueue = false;

--- a/Magitek/Rotations/Dancer.cs
+++ b/Magitek/Rotations/Dancer.cs
@@ -67,7 +67,9 @@ namespace Magitek.Rotations
             if (await Casting.TrackSpellCast()) return true;
             await Casting.CheckForSuccessfulCast();
 
-            if (await GambitLogic.Gambit()) return true;
+            if (await GambitLogic.Gambit())
+                return true;
+
             return false;
         }
 
@@ -100,7 +102,6 @@ namespace Magitek.Rotations
                 return false;
 
             if (await CustomOpenerLogic.Opener()) return true;
-            if (await GambitLogic.Gambit()) return true;
 
             //LimitBreak
             if (Aoe.ForceLimitBreak()) return true;
@@ -116,18 +117,19 @@ namespace Magitek.Rotations
             if (Core.Me.HasAura(Auras.StandardStep) || Core.Me.HasAura(Auras.TechnicalStep))
                 return false;
 
-            if (DancerRoutine.GlobalCooldown.CanWeave())
+            if ( (DancerRoutine.GlobalCooldown.CanWeave() && !Casting.SpellCastHistory.Take(2).Any(s => s.Spell == Spells.Tillana || s.Spell == Spells.DoubleStandardFinish || s.Spell == Spells.QuadrupleTechnicalFinish))
+                || (DancerRoutine.GlobalCooldown.CanWeave(1) && Casting.SpellCastHistory.Take(2).Any(s => s.Spell == Spells.Tillana || s.Spell == Spells.DoubleStandardFinish || s.Spell == Spells.QuadrupleTechnicalFinish)) )
             {
                 //utility
                 if (await PhysicalDps.Interrupt(DancerSettings.Instance)) return true;
                 if (await PhysicalDps.SecondWind(DancerSettings.Instance)) return true;
-                if (await Buff.UsePotion()) return true;
-                
+
                 //Buff
+                if (await Buff.UsePotion()) return true;
                 if (await Buff.Devilment()) return true;
-                if (await Buff.Flourish()) return true;
 
                 //OGCD
+                if (await Buff.Flourish()) return true;
                 if (await Aoe.FanDance4()) return true;
                 if (await Aoe.FanDance3()) return true;
                 if (await Aoe.FanDance2()) return true;

--- a/Magitek/Rotations/Samurai.cs
+++ b/Magitek/Rotations/Samurai.cs
@@ -71,9 +71,6 @@ namespace Magitek.Rotations
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
 
-            if (await GambitLogic.Gambit())
-                return true;
-
             if (!SpellQueueLogic.SpellQueue.Any())
                 SpellQueueLogic.InSpellQueue = false;
 

--- a/Magitek/Styles/CheckBoxes.xaml
+++ b/Magitek/Styles/CheckBoxes.xaml
@@ -140,6 +140,69 @@
         </Setter>
     </Style>
 
+    <Style x:Key="CheckBoxIsActiveFlat" TargetType="{x:Type CheckBox}">
+        <Setter Property="FontFamily" Value="Segoe UI Symbol" />
+        <Setter Property="FontWeight" Value="Normal" />
+        <Setter Property="Foreground" Value="{DynamicResource Light}" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type CheckBox}">
+                    <Grid Background="Transparent">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition />
+                        </Grid.ColumnDefinitions>
+
+                        <Border Name="CheckboxBorder" Grid.Column="0" Width="16" Height="16" CornerRadius="2">
+                            <Grid>
+                                <Path Name="Checked"
+                                      Height="8"
+                                      Data="F1 M 0,110L 47.6667,62L 102,117.333L 218.667,0L 266,48L 102,212.333L 0,110 Z"
+                                      Fill="{DynamicResource Background}"
+                                      Opacity="0.90"
+                                      Stretch="Uniform"
+                                      UseLayoutRounding="False"
+                                      Visibility="Hidden">
+                                </Path>
+
+                                <Path Name="Unchecked"
+                                      Height="8"
+                                      Data="M7.1999998,0L16,8.7999997 24.799999,0 32,7.1999998 23.2,16 32,24.799999 24.799999,32 16,23.2 7.1999998,32 0,24.799999 8.7999997,16 0,7.1999998z"
+                                      Fill="{DynamicResource Background}"
+                                      Opacity="0.90"
+                                      Stretch="Uniform"
+                                      UseLayoutRounding="False"
+                                      Visibility="Hidden">
+                                </Path>
+                            </Grid>
+                        </Border>
+
+                        <Border Grid.Column="1" Padding="5,0,0,0">
+                            <ContentPresenter VerticalAlignment="Center" Content="{TemplateBinding Content}" />
+                        </Border>
+                    </Grid>
+
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsChecked" Value="True">
+                            <Trigger.Setters>
+                                <Setter TargetName="Checked" Property="Visibility" Value="Visible" />
+                                <Setter TargetName="CheckboxBorder" Property="Background" Value="{DynamicResource Success}" />
+                                <Setter TargetName="CheckboxBorder" Property="BorderBrush" Value="{DynamicResource Success}" />
+                            </Trigger.Setters>
+                        </Trigger>
+                        <Trigger Property="IsChecked" Value="False">
+                            <Trigger.Setters>
+                                <Setter TargetName="Unchecked" Property="Visibility" Value="Visible" />
+                                <Setter TargetName="CheckboxBorder" Property="Background" Value="{DynamicResource Danger}" />
+                                <Setter TargetName="CheckboxBorder" Property="BorderBrush" Value="{DynamicResource Danger}" />
+                            </Trigger.Setters>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <Style x:Key="CheckBoxFlatSmall" TargetType="{x:Type CheckBox}">
         <Setter Property="FontFamily" Value="Segoe UI Symbol" />
         <Setter Property="FontWeight" Value="Normal" />

--- a/Magitek/Utilities/Potion.cs
+++ b/Magitek/Utilities/Potion.cs
@@ -25,7 +25,7 @@ namespace Magitek.Utilities
             {
                 Logger.WriteInfo($@"Use potion : {potionItem.Name}");
                 potionItem.UseItem(Core.Me);
-                await Coroutine.Wait(100, () => false);
+                await Coroutine.Wait(700, () => false);
 
                 if (potionItem == null || !potionItem.CanUse())
                     return true;

--- a/Magitek/Views/UserControls/Dancer/Buffs.xaml
+++ b/Magitek/Views/UserControls/Dancer/Buffs.xaml
@@ -57,9 +57,7 @@
                     <CheckBox Margin="5" Content="Use Flourish" IsChecked="{Binding DancerSettings.UseFlourish, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                 </StackPanel>
                 <StackPanel Orientation="Horizontal">
-                    <CheckBox Margin="5" Content="Use Devilment    " IsChecked="{Binding DancerSettings.UseDevilment, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                    <RadioButton Margin="5" Foreground="White" Content="With Flourish        " GroupName="DevilmentStrategy" IsChecked="{Binding DancerSettings.DevilmentWithFlourish, Mode=TwoWay}" />
-                    <RadioButton Margin="5" Foreground="White" Content="Before Technical Step" GroupName="DevilmentStrategy" IsChecked="{Binding DancerSettings.DevilmentWithTechnicalStep, Mode=TwoWay}" />
+                    <CheckBox Margin="5" Content="Use Devilment" IsChecked="{Binding DancerSettings.UseDevilment, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                 </StackPanel>
             </StackPanel>
         </controls:SettingsBlock>


### PR DESCRIPTION
- OPENER: Move active button on the left for Opener
- OPENER: Add a way to enable/disable an opener in Opener UI (Usefull when you have multiple opener and don't want to specify a Zone or delete it). be careful, it is deactivated by default. So do not forget to activate your openers
- DNC: Fix Dance drift
- DNC: Fix Drift due to some oGCD
- DNC: Remove Toggle DevilmentWithFlourish and DevilmentWithTechnicalStep
- DNC: remove Gambit execution define twice
- SAM: remove Gambit execution define twice
- BLU: remove Gambit execution define twice