### PR TITLE
Fix: Added Null checks to Group.UpdateAllies()

### DIFF
--- a/Magitek/Utilities/Group.cs
+++ b/Magitek/Utilities/Group.cs
@@ -15,10 +15,10 @@ namespace Magitek.Utilities
 {
     public static class Group
     {
-        private static readonly FrameCachedObject<IEnumerable<Character>> _allianceMembers = new(() => GameObjectManager.GetObjectsOfType<BattleCharacter>().Where(r => r.Type == GameObjectType.Pc && r.IsTargetable && r.InLineOfSight()));
-        private static readonly FrameCachedObject<IEnumerable<Character>> _pets = new(() => GameObjectManager.GetObjectsByNPCIds<GameObject>(PetIds).Where(r => r.IsTargetable && r.InLineOfSight() && r.Distance(Core.Me) <= 30).Select(r => r as Character));
-        private static readonly FrameCachedObject<IEnumerable<BattleCharacter>> _allies = new(() => GameObjectManager.GetObjectsOfType<BattleCharacter>().Where(r => !r.CanAttack && r.InLineOfSight()));
-        private static readonly FrameCachedObject<IEnumerable<BattleCharacter>> _battleCharacters = new(() => PartyManager.RawMembers.Select(r => r.BattleCharacter).Where(i=> i.InLineOfSight()));
+        private static readonly FrameCachedObject<IEnumerable<Character>> _allianceMembers = new(() => GameObjectManager.GetObjectsOfType<BattleCharacter>().Where(i=> i!=null && i.IsValid).Where(r => r.Type == GameObjectType.Pc && r.IsTargetable && r.InLineOfSight()));
+        private static readonly FrameCachedObject<IEnumerable<Character>> _pets = new(() => GameObjectManager.GetObjectsByNPCIds<GameObject>(PetIds).Where(i=> i!=null && i.IsValid).Where(r => r.IsTargetable && r.InLineOfSight() && r.Distance(Core.Me) <= 30).OfType<Character>().Where(i=> i.IsValid));
+        private static readonly FrameCachedObject<IEnumerable<BattleCharacter>> _allies = new(() => GameObjectManager.GetObjectsOfType<BattleCharacter>().Where(i=> i!=null && i.IsValid).Where(r => r.CanAttack && r.InLineOfSight()));
+        private static readonly FrameCachedObject<IEnumerable<BattleCharacter>> _battleCharacters = new(() => PartyManager.RawMembers.Select(r => r?.BattleCharacter).Where(i=> i!=null && i.IsValid).Where(i=> i.InLineOfSight()));
         public static IEnumerable<Character> AllianceMembers
         {
             get
@@ -67,7 +67,7 @@ namespace Magitek.Utilities
 
             foreach (var ally in _battleCharacters.Value)
             {
-                if (ally == null)
+                if (ally == null || !ally.IsValid)
                     continue;
 
                 if (BaseSettings.Instance.DebugHealingListsPrintToLog == true)


### PR DESCRIPTION
Attempting to avoid an exception like this one:

> [09:21:44.653 D] Buddy.Coroutines.CoroutineUnhandledException: Exception was thrown by coroutine
 ---> Buddy.Coroutines.CoroutineUnhandledException: Exception was thrown by coroutine
 ---> System.NullReferenceException: Object reference not set to an instance of an object.
   at Magitek.Utilities.Group.<>c.<.cctor>b__29_9(BattleCharacter i)
   at Magitek.Utilities.Group.UpdateAllies(Action extensions)
   at Magitek.Utilities.Managers.RotationComposites.Heal()
   at TreeSharp.ActionRunCoroutine.<>c__DisplayClass4_1.TestSchemaAttribute.MoveNext()
   --- End of inner exception stack trace ---
   at Buddy.Coroutines.Coroutine.CheckPostConditions(Boolean shouldBeCanceled)
   at Buddy.Coroutines.Coroutine.Resume(Boolean forStop)
   at Buddy.Coroutines.Coroutine.Resume()
   at TreeSharp.ActionRunCoroutine.Run(Object context)

Not sure what else could be null in that function